### PR TITLE
Add service protocols and refactor view models

### DIFF
--- a/Cantinarr/Core/Auth/AuthManager.swift
+++ b/Cantinarr/Core/Auth/AuthManager.swift
@@ -22,10 +22,10 @@ actor AuthManager {
 
     // MARK: – Config injected once at app launch
 
-    private var service: OverseerrAPIService!
+    private var service: OverseerrServiceType!
 
     /// Call once from `App.bootstrap` after you know which Overseerr you're talking to.
-    func configure(service: OverseerrAPIService) {
+    func configure(service: OverseerrServiceType) {
         self.service = service
         lastProbe = nil
         Task { await probeSession() }

--- a/Cantinarr/Features/MediaDetail/Logic/MediaDetailViewModel.swift
+++ b/Cantinarr/Features/MediaDetail/Logic/MediaDetailViewModel.swift
@@ -22,12 +22,12 @@ final class MediaDetailViewModel: ObservableObject {
     @Published var showTrailerPlayer: Bool = false
 
     //    private let id: Int
-    private let service: OverseerrAPIService
+    private let service: OverseerrServiceType
     private let userSession: UserSession
 
     init(id: Int,
          mediaType: MediaType,
-         service: OverseerrAPIService,
+         service: OverseerrServiceType,
          userSession: UserSession)
     {
         self.id = id

--- a/Cantinarr/Features/MediaDetail/UI/MediaDetailView.swift
+++ b/Cantinarr/Features/MediaDetail/UI/MediaDetailView.swift
@@ -21,7 +21,7 @@ struct MediaDetailView: View {
 
     init(id: Int,
          mediaType: MediaType,
-         service: OverseerrAPIService,
+         service: OverseerrServiceType,
          userSession: UserSession)
     {
         _vm = StateObject(

--- a/Cantinarr/Features/OverseerrUsers/Logic/TrendingViewModel.swift
+++ b/Cantinarr/Features/OverseerrUsers/Logic/TrendingViewModel.swift
@@ -9,7 +9,7 @@ final class TrendingViewModel: ObservableObject {
     typealias MediaItem = OverseerrUsersViewModel.MediaItem // reuse struct
 
     // Dependencies
-    private let service: OverseerrAPIService
+    private let service: OverseerrServiceType
 
     // Paging helper
     private var loader = PagedLoader()
@@ -21,7 +21,7 @@ final class TrendingViewModel: ObservableObject {
 
     // MARK: – Init
 
-    init(service: OverseerrAPIService) {
+    init(service: OverseerrServiceType) {
         self.service = service
     }
 

--- a/Cantinarr/Features/OverseerrUsers/Networking/OverseerrAPIService.swift
+++ b/Cantinarr/Features/OverseerrUsers/Networking/OverseerrAPIService.swift
@@ -401,3 +401,5 @@ extension OverseerrAPIService {
 
 // Make OverseerrAPIService satisfy OverseerrUsersService
 extension OverseerrAPIService: OverseerrUsersService {}
+
+extension OverseerrAPIService: OverseerrServiceType {}

--- a/Cantinarr/Features/OverseerrUsers/Networking/OverseerrServiceType.swift
+++ b/Cantinarr/Features/OverseerrUsers/Networking/OverseerrServiceType.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+@MainActor
+protocol OverseerrServiceType {
+    func isAuthenticated() async -> Bool
+    func fetchTrending(providerIds: [Int], page: Int) async throws -> OverseerrAPIService.DiscoverResponse<OverseerrAPIService.TrendingItem>
+    func movieDetail(id: Int) async throws -> OverseerrAPIService.MovieDetail
+    func tvDetail(id: Int) async throws -> OverseerrAPIService.TVDetail
+    func request(mediaId id: Int, isMovie: Bool) async throws
+    func reportIssue(mediaId id: Int, type: String, message: String) async throws
+}

--- a/Cantinarr/Features/Radarr/Logic/RadarrMovieDetailViewModel.swift
+++ b/Cantinarr/Features/Radarr/Logic/RadarrMovieDetailViewModel.swift
@@ -91,7 +91,7 @@ class RadarrMovieDetailViewModel: ObservableObject {
         do {
             // When sending movieToUpdate to radarrService.updateMovie,
             // ensure it's the complete, correct payload Radarr expects for an update.
-            let updatedMovie = try await radarrService.updateMovie(movieToUpdate)
+            let updatedMovie = try await radarrService.updateMovie(movieToUpdate, moveFiles: false)
             movie = updatedMovie
             commandStatusMessage = movieToUpdate.monitored ? "Movie is now monitored." : "Movie is no longer monitored."
             showCommandStatusAlert = true
@@ -139,7 +139,7 @@ class RadarrMovieDetailViewModel: ObservableObject {
     func deleteMovie(alsoDeleteFiles: Bool) async {
         guard let movieToDelete = movie else { return }
         do {
-            try await radarrService.deleteMovie(movieToDelete.id, deleteFiles: alsoDeleteFiles)
+            try await radarrService.deleteMovie(movieToDelete.id, deleteFiles: alsoDeleteFiles, addImportExclusion: false)
             commandStatusMessage = "Movie deleted successfully."
             showCommandStatusAlert = true
             // After deletion, the view should probably be dismissed or state cleared

--- a/Cantinarr/Features/Radarr/Logic/RadarrMovieDetailViewModel.swift
+++ b/Cantinarr/Features/Radarr/Logic/RadarrMovieDetailViewModel.swift
@@ -15,12 +15,12 @@ class RadarrMovieDetailViewModel: ObservableObject {
     @Published var commandStatusMessage: String? // For feedback on actions like search
     @Published var showCommandStatusAlert: Bool = false
 
-    private let radarrService: RadarrAPIService
+    private let radarrService: RadarrServiceType
     let movieId: Int
 
     private var cancellables = Set<AnyCancellable>()
 
-    init(movieId: Int, radarrService: RadarrAPIService) {
+    init(movieId: Int, radarrService: RadarrServiceType) {
         self.movieId = movieId
         self.radarrService = radarrService
     }

--- a/Cantinarr/Features/Radarr/Logic/RadarrMoviesViewModel.swift
+++ b/Cantinarr/Features/Radarr/Logic/RadarrMoviesViewModel.swift
@@ -12,11 +12,11 @@ class RadarrMoviesViewModel: ObservableObject {
     @Published var connectionError: String? = nil
     @Published var qualityProfiles: [Int: String] = [:] // [ID: Name]
 
-    let service: RadarrAPIService
+    let service: RadarrServiceType
     private var pageLoader =
         PagedLoader() // If Radarr movie list is paginated server-side (often it's not, but good for consistency)
 
-    init(service: RadarrAPIService) {
+    init(service: RadarrServiceType) {
         self.service = service
     }
 

--- a/Cantinarr/Features/Radarr/RadarrAPIService.swift
+++ b/Cantinarr/Features/Radarr/RadarrAPIService.swift
@@ -361,3 +361,5 @@ class RadarrAPIService: ObservableObject { // ADDED ObservableObject conformance
         }
     }
 }
+
+extension RadarrAPIService: RadarrServiceType {}

--- a/Cantinarr/Features/Radarr/RadarrServiceType.swift
+++ b/Cantinarr/Features/Radarr/RadarrServiceType.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+@MainActor
+protocol RadarrServiceType {
+    func getMovies() async throws -> [RadarrMovie]
+    func getMovie(id: Int) async throws -> RadarrMovie
+    func getQualityProfiles() async throws -> [RadarrQualityProfile]
+    func getSystemStatus() async throws -> RadarrSystemStatus
+    func searchForMovie(_ movieId: Int) async throws -> RadarrCommandResponse
+    func updateMovie(_ movie: RadarrMovie, moveFiles: Bool) async throws -> RadarrMovie
+    func deleteMovie(_ movieId: Int, deleteFiles: Bool, addImportExclusion: Bool) async throws
+}

--- a/Cantinarr/Features/Radarr/UI/RadarrHomeEntry.swift
+++ b/Cantinarr/Features/Radarr/UI/RadarrHomeEntry.swift
@@ -8,10 +8,10 @@ struct RadarrHomeEntry: View {
     let settings: RadarrSettings
     var openSettingsSheetForCurrentService: () -> Void
 
-    // The RadarrAPIService instance itself doesn't need to be a @StateObject
-    // if it doesn't have @Published properties that this view directly observes.
-    // It's created once and passed to ViewModels that ARE @StateObjects.
-    private let radarrServiceInstance: RadarrAPIService
+    // The Radarr service instance doesn't need to be a @StateObject if it doesn't
+    // have @Published properties that this view observes. It's created once and
+    // passed to ViewModels that ARE @StateObjects.
+    private let radarrServiceInstance: RadarrServiceType
 
     @State private var initialConnectionError: String? = nil
     @State private var isLoadingInitialCheck: Bool = true

--- a/Cantinarr/Features/Radarr/UI/RadarrMovieDetailView.swift
+++ b/Cantinarr/Features/Radarr/UI/RadarrMovieDetailView.swift
@@ -18,7 +18,7 @@ struct RadarrMovieDetailView: View {
     @State private var taglineHeight: CGFloat = .zero // For dynamic header height calculation
     @State private var showDeleteConfirmation = false
 
-    init(movieId: Int, radarrService: RadarrAPIService) {
+    init(movieId: Int, radarrService: RadarrServiceType) {
         _viewModel = StateObject(wrappedValue: RadarrMovieDetailViewModel(
             movieId: movieId,
             radarrService: radarrService


### PR DESCRIPTION
## Summary
- introduce `OverseerrServiceType` and `RadarrServiceType` protocols
- conform API services to the new protocols
- refactor view models and app logic to depend on these abstractions

## Testing
- `sh Scripts/lint.sh` *(fails: SwiftLint/SwiftFormat not installed)*