### PR TITLE
Standardize API error handling

### DIFF
--- a/Cantinarr/Core/Models/APIServiceError.swift
+++ b/Cantinarr/Core/Models/APIServiceError.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+/// Generic error type for API services.
+enum APIServiceError: Error, LocalizedError {
+    case unauthorized
+    case apiError(message: String, statusCode: Int)
+    case invalidResponse
+    case network(Error)
+
+    var errorDescription: String? {
+        switch self {
+        case .unauthorized:
+            return "Authentication required."
+        case let .apiError(message, _):
+            return message
+        case .invalidResponse:
+            return "Invalid response from server."
+        case let .network(error):
+            return error.localizedDescription
+        }
+    }
+}

--- a/Cantinarr/Features/OverseerrUsers/Logic/OverseerrUsersViewModel.swift
+++ b/Cantinarr/Features/OverseerrUsers/Logic/OverseerrUsersViewModel.swift
@@ -191,7 +191,7 @@ class OverseerrUsersViewModel: ObservableObject {
             if case .authenticated = authState, results.isEmpty && searchQuery.isEmpty && activeKeywordIDs.isEmpty {
                 await loadMedia(reset: true)
             }
-        } catch is AuthError {
+        } catch is OverseerrError {
             recoverFromAuthFailure()
         } catch {
             print("🔴 Provider load error: \(error.localizedDescription)")
@@ -272,7 +272,7 @@ class OverseerrUsersViewModel: ObservableObject {
             loader.endLoading(next: responseTotalPages)
 
             if !watchProviders.isEmpty { clearConnectionError() }
-        } catch is AuthError {
+        } catch is OverseerrError {
             loader.cancelLoading(); recoverFromAuthFailure()
         } catch {
             print("🔴 Media load error (\(selectedMedia)): \(error.localizedDescription)")
@@ -350,7 +350,7 @@ class OverseerrUsersViewModel: ObservableObject {
             loader.endLoading(next: resp.totalPages)
 
             if !watchProviders.isEmpty { clearConnectionError() }
-        } catch is AuthError {
+        } catch is OverseerrError {
             loader.cancelLoading(); recoverFromAuthFailure()
         } catch {
             print("🔴 Search error: \(error.localizedDescription)")
@@ -370,7 +370,7 @@ class OverseerrUsersViewModel: ObservableObject {
         do {
             let raw = try await service.keywordSearch(query: query)
             keywordSuggestions = await filterUsableKeywords(raw)
-        } catch is AuthError {
+        } catch is OverseerrError {
             // Handled by recoverFromAuthFailure
         } catch {
             keywordSuggestions = []
@@ -440,7 +440,7 @@ class OverseerrUsersViewModel: ObservableObject {
                             page: 1
                         )
                         if !tv.results.isEmpty { return kw }
-                    } catch is AuthError {
+                    } catch is OverseerrError {
                         await self.recoverFromAuthFailure()
                     } catch {
                         print("⚠️ Error probing keyword \(kw.name): \(error.localizedDescription)")
@@ -479,8 +479,8 @@ class OverseerrUsersViewModel: ObservableObject {
                 mediaType: .movie
             ) }
             movieRecLoader.endLoading(next: resp.totalPages)
-        } catch is AuthError {
-            recoverFromAuthFailure(); movieFetchError = AuthError.notAuthenticated
+        } catch is OverseerrError {
+            recoverFromAuthFailure(); movieFetchError = OverseerrError.notAuthenticated
         } catch {
             movieFetchError = error; print("🔴 Movie recommendations error: \(error.localizedDescription)")
             movieRecs = []; movieRecLoader.reset()
@@ -493,8 +493,8 @@ class OverseerrUsersViewModel: ObservableObject {
             tvRecs = resp.results
                 .map { MediaItem(id: $0.id, title: $0.name, posterPath: $0.posterPath, mediaType: .tv) }
             tvRecLoader.endLoading(next: resp.totalPages)
-        } catch is AuthError {
-            recoverFromAuthFailure(); tvFetchError = AuthError.notAuthenticated
+        } catch is OverseerrError {
+            recoverFromAuthFailure(); tvFetchError = OverseerrError.notAuthenticated
         } catch {
             tvFetchError = error; print("🔴 TV recommendations error: \(error.localizedDescription)")
             tvRecs = []; tvRecLoader.reset()
@@ -502,17 +502,17 @@ class OverseerrUsersViewModel: ObservableObject {
         isLoadingTvRecs = false
 
         // Error Reporting
-        if let mvErr = movieFetchError, !(mvErr is AuthError),
-           let tvErr = tvFetchError, !(tvErr is AuthError)
+        if let mvErr = movieFetchError, !(mvErr is OverseerrError),
+           let tvErr = tvFetchError, !(tvErr is OverseerrError)
         {
             connectionError = "Failed to load recommendations."
         } else if connectionError == nil && (movieFetchError != nil || tvFetchError != nil) {
             if let mvErr = movieFetchError,
-               !(mvErr is AuthError)
+               !(mvErr is OverseerrError)
             {
                 connectionError = "Failed to load movie recommendations. \(mvErr.localizedDescription)"
             } else if let tvErr = tvFetchError,
-                      !(tvErr is AuthError)
+                      !(tvErr is OverseerrError)
             {
                 connectionError = "Failed to load TV recommendations. \(tvErr.localizedDescription)"
             }
@@ -555,7 +555,7 @@ class OverseerrUsersViewModel: ObservableObject {
                 ) }
                 movieRecs.append(contentsOf: more)
                 movieRecLoader.endLoading(next: resp.totalPages)
-            } catch is AuthError {
+            } catch is OverseerrError {
                 movieRecLoader.cancelLoading(); recoverFromAuthFailure()
             } catch {
                 movieRecLoader
@@ -585,7 +585,7 @@ class OverseerrUsersViewModel: ObservableObject {
                 ) }
                 tvRecs.append(contentsOf: more)
                 tvRecLoader.endLoading(next: resp.totalPages)
-            } catch is AuthError {
+            } catch is OverseerrError {
                 tvRecLoader.cancelLoading(); recoverFromAuthFailure()
             } catch {
                 tvRecLoader

--- a/Cantinarr/Features/OverseerrUsers/Logic/TrendingViewModel.swift
+++ b/Cantinarr/Features/OverseerrUsers/Logic/TrendingViewModel.swift
@@ -73,11 +73,11 @@ final class TrendingViewModel: ObservableObject {
             if loader.page == 2 {
                 connectionError = nil
             }
-        } catch is AuthError { // More specific: catch AuthError
+        } catch is OverseerrError { // More specific: catch OverseerrError
             // Auth errors are primarily handled by OverseerrUsersViewModel's authState
             // and AuthManager. This VM doesn't need to set connectionError for this.
             loader.cancelLoading()
-            print("Trending fetch failed due to AuthError.")
+            print("Trending fetch failed due to OverseerrError.")
         } catch {
             loader.cancelLoading()
             // Only set error if items are empty, otherwise it might be a pagination error

--- a/Cantinarr/Features/OverseerrUsers/Networking/OverseerrAPIService+Authentication.swift
+++ b/Cantinarr/Features/OverseerrUsers/Networking/OverseerrAPIService+Authentication.swift
@@ -18,13 +18,7 @@ extension OverseerrAPIService {
 
     func fetchCurrentUser() async throws -> User {
         let request = URLRequest(url: baseURL.appendingPathComponent("auth/me"))
-        let (data, resp) = try await data(for: request)
-        guard resp.statusCode == 200 else {
-            throw URLError(
-                .badServerResponse,
-                userInfo: [NSLocalizedDescriptionKey: "Failed to fetch current user. Status: \(resp.statusCode)"]
-            )
-        }
+        let (data, _) = try await data(for: request)
         return try jsonDecoder.decode(User.self, from: data)
     }
 
@@ -38,12 +32,7 @@ extension OverseerrAPIService {
         request.setValue("application/json", forHTTPHeaderField: "Accept")
         request.httpBody = Data()
 
-        let (data, resp) = try await data(for: request)
-        guard let http = resp as? HTTPURLResponse, http.statusCode == 200 else {
-            let body = String(data: data, encoding: .utf8) ?? "(empty)"
-            print("🛑 /api/v1/auth/plex returned status \((resp as? HTTPURLResponse)?.statusCode ?? -1):\n\(body)")
-            throw URLError(.badServerResponse)
-        }
+        let (data, _) = try await data(for: request)
 
         struct Redirect: Decodable { let url: String }
         let redirect = try JSONDecoder().decode(Redirect.self, from: data)
@@ -61,9 +50,6 @@ extension OverseerrAPIService {
         let body = ["authToken": plexToken]
         req.httpBody = try JSONEncoder().encode(body)
 
-        let (_, resp) = try await data(for: req)
-        guard (resp as? HTTPURLResponse)?.statusCode == 200 else {
-            throw URLError(.userAuthenticationRequired)
-        }
+        _ = try await data(for: req)
     }
 }

--- a/Cantinarr/Features/OverseerrUsers/Networking/OverseerrAPIService+Discover.swift
+++ b/Cantinarr/Features/OverseerrUsers/Networking/OverseerrAPIService+Discover.swift
@@ -11,10 +11,7 @@ extension OverseerrAPIService {
         let endpoint = isMovie ? "watchproviders/movies" : "watchproviders/tv"
         var comps = URLComponents(url: baseURL.appendingPathComponent(endpoint), resolvingAgainstBaseURL: false)!
         comps.queryItems = [.init(name: "watchRegion", value: Locale.current.regionCode ?? "US")]
-        let (d, resp) = try await data(for: URLRequest(url: comps.url!))
-        guard let http = resp as? HTTPURLResponse else { throw URLError(.badServerResponse) }
-        if http.statusCode == 401 || http.statusCode == 403 { throw AuthError.notAuthenticated }
-        guard http.statusCode == 200 else { throw URLError(.badServerResponse) }
+        let (d, _) = try await data(for: URLRequest(url: comps.url!))
         return try jsonDecoder.decode([WatchProvider].self, from: d)
     }
 
@@ -28,10 +25,7 @@ extension OverseerrAPIService {
         guard !query.isEmpty else { return [] }
         var comps = URLComponents(url: baseURL.appendingPathComponent("search/keyword"), resolvingAgainstBaseURL: false)!
         comps.queryItems = [.init(name: "query", value: query)]
-        let (data, resp) = try await data(for: URLRequest(url: comps.url!))
-        guard let http = resp as? HTTPURLResponse else { throw URLError(.badServerResponse) }
-        if http.statusCode == 401 || http.statusCode == 403 { throw AuthError.notAuthenticated }
-        guard http.statusCode == 200 else { throw URLError(.badServerResponse) }
+        let (data, _) = try await data(for: URLRequest(url: comps.url!))
         let wrapper = try jsonDecoder.decode(DiscoverResponse<Keyword>.self, from: data)
         return wrapper.results
     }
@@ -88,8 +82,7 @@ extension OverseerrAPIService {
             .init(name: "query", value: query),
             .init(name: "page", value: "\(page)")
         ]
-        let (data, resp) = try await data(for: URLRequest(url: comps.url!))
-        guard (resp as? HTTPURLResponse)?.statusCode == 200 else { throw URLError(.badServerResponse) }
+        let (data, _) = try await data(for: URLRequest(url: comps.url!))
         return try jsonDecoder.decode(DiscoverResponse<SearchItem>.self, from: data)
     }
 
@@ -108,10 +101,7 @@ extension OverseerrAPIService {
         }
         comps.queryItems = q
 
-        let (d, resp) = try await data(for: URLRequest(url: comps.url!))
-        guard let http = resp as? HTTPURLResponse else { throw URLError(.badServerResponse) }
-        if http.statusCode == 401 || http.statusCode == 403 { throw AuthError.notAuthenticated }
-        guard http.statusCode == 200 else { throw URLError(.badServerResponse) }
+        let (d, _) = try await data(for: URLRequest(url: comps.url!))
         return try jsonDecoder.decode(DiscoverResponse<T>.self, from: d)
     }
 

--- a/Cantinarr/Features/OverseerrUsers/Networking/OverseerrAPIService+MediaDetail.swift
+++ b/Cantinarr/Features/OverseerrUsers/Networking/OverseerrAPIService+MediaDetail.swift
@@ -77,8 +77,7 @@ extension OverseerrAPIService {
     // MARK: - Helpers
     private func fetchJSON<T: Decodable>(_ endpoint: String) async throws -> T {
         let url = baseURL.appendingPathComponent(endpoint)
-        let (data, resp) = try await data(for: URLRequest(url: url))
-        guard resp.statusCode == 200 else { throw URLError(.badServerResponse) }
+        let (data, _) = try await data(for: URLRequest(url: url))
         return try jsonDecoder.decode(T.self, from: data)
     }
 
@@ -87,7 +86,6 @@ extension OverseerrAPIService {
         req.httpMethod = "POST"
         req.setValue("application/json", forHTTPHeaderField: "Content-Type")
         req.httpBody = try JSONSerialization.data(withJSONObject: body)
-        let (_, resp) = try await data(for: req)
-        guard resp.statusCode == 200 else { throw URLError(.badServerResponse) }
+        _ = try await data(for: req)
     }
 }

--- a/Cantinarr/Features/Radarr/Logic/RadarrMovieDetailViewModel.swift
+++ b/Cantinarr/Features/Radarr/Logic/RadarrMovieDetailViewModel.swift
@@ -37,7 +37,7 @@ class RadarrMovieDetailViewModel: ObservableObject {
             let fetchedMovie = try await radarrService.getMovie(id: movieId)
             movie = fetchedMovie
             await fetchQualityProfileName(id: fetchedMovie.qualityProfileId)
-        } catch let RadarrAPIService.RadarrError.apiError(message, statusCode) {
+        } catch let APIServiceError.apiError(message: message, statusCode: statusCode) {
             self.error = "Radarr API Error (\(statusCode)): \(message)"
         } catch {
             self.error = "Failed to load movie details: \(error.localizedDescription)"

--- a/Cantinarr/Features/Radarr/Logic/RadarrMoviesViewModel.swift
+++ b/Cantinarr/Features/Radarr/Logic/RadarrMoviesViewModel.swift
@@ -32,7 +32,7 @@ class RadarrMoviesViewModel: ObservableObject {
 
         do {
             movies = try await service.getMovies()
-        } catch let RadarrAPIService.RadarrError.apiError(message, statusCode) {
+        } catch let APIServiceError.apiError(message: message, statusCode: statusCode) {
             self.connectionError = "Radarr API Error (\(statusCode)): \(message)"
         } catch {
             connectionError = "Failed to load movies: \(error.localizedDescription)"

--- a/Cantinarr/Features/Radarr/UI/RadarrHomeEntry.swift
+++ b/Cantinarr/Features/Radarr/UI/RadarrHomeEntry.swift
@@ -36,7 +36,7 @@ struct RadarrHomeEntry: View {
         do {
             // Use the stored instance for the check
             _ = try await radarrServiceInstance.getSystemStatus()
-        } catch let RadarrAPIService.RadarrError.apiError(message, statusCode) {
+        } catch let APIServiceError.apiError(message: message, statusCode: statusCode) {
             self.initialConnectionError = "Radarr API Error (\(statusCode)): \(message)"
         } catch {
             initialConnectionError = "Could not connect to Radarr: \(error.localizedDescription)"


### PR DESCRIPTION
## Summary
- add `APIServiceError` to unify error types
- introduce `OverseerrError` and update request helper
- adjust Overseerr API extensions to rely on unified errors
- switch Radarr API to return `APIServiceError`
- update ViewModels to handle new error cases

## Testing
- `sh Scripts/lint.sh` *(fails: SwiftLint not installed)*