### PR TITLE
Rename Overseerr auth components

### DIFF
--- a/Cantinarr/App/CantinarrApp.swift
+++ b/Cantinarr/App/CantinarrApp.swift
@@ -13,13 +13,13 @@ struct CantinarrApp: App {
     @StateObject private var userSession = UserSession()
 
     init() {
-        // Bootstrap AuthManager once.
+        // Bootstrap OverseerrAuthManager once.
         // The demo environment always has at least one service:
         if let demoSvc = EnvironmentsStore().selectedServiceInstance?
             .decode(OverseerrSettings.self)
         {
             let svc = OverseerrAPIService(settings: demoSvc)
-            Task { await AuthManager.shared.configure(service: svc) }
+            Task { await OverseerrAuthManager.shared.configure(service: svc) }
         }
     }
 

--- a/Cantinarr/Core/Auth/OverseerrAuthManager.swift
+++ b/Cantinarr/Core/Auth/OverseerrAuthManager.swift
@@ -1,24 +1,24 @@
-// File: AuthManager.swift
-// Purpose: Defines AuthManager component for Cantinarr
+// File: OverseerrAuthManager.swift
+// Purpose: Defines OverseerrAuthManager component for Cantinarr
 
 import Combine
 import Foundation
 
 /// Actor = thread‑safe without extra locks.
-actor AuthManager {
+actor OverseerrAuthManager {
     // MARK: – Public singleton
 
-    static let shared = AuthManager()
+    static let shared = OverseerrAuthManager()
     private init() {}
 
     // MARK: – Published state
 
-    nonisolated let subject = CurrentValueSubject<AuthState, Never>(.unknown)
-    nonisolated var publisher: AnyPublisher<AuthState, Never> {
+    nonisolated let subject = CurrentValueSubject<OverseerrAuthState, Never>(.unknown)
+    nonisolated var publisher: AnyPublisher<OverseerrAuthState, Never> {
         subject.eraseToAnyPublisher()
     }
 
-    nonisolated var value: AuthState { subject.value }
+    nonisolated var value: OverseerrAuthState { subject.value }
 
     // MARK: – Config injected once at app launch
 

--- a/Cantinarr/Core/Auth/OverseerrAuthState.swift
+++ b/Cantinarr/Core/Auth/OverseerrAuthState.swift
@@ -1,11 +1,11 @@
-// File: AuthState.swift
-// Purpose: Defines AuthState component for Cantinarr
+// File: OverseerrAuthState.swift
+// Purpose: Defines OverseerrAuthState component for Cantinarr
 
 import Foundation
 import SwiftUI
 
 /// Single source of truth for Overseerr session state.
-enum AuthState: Equatable {
+enum OverseerrAuthState: Equatable {
     case unknown // still probing
     case authenticated(expiry: Date?) // expiry lets us pre‑empt logout
     case unauthenticated

--- a/Cantinarr/Core/Helpers/OverseerrAuthContextProvider.swift
+++ b/Cantinarr/Core/Helpers/OverseerrAuthContextProvider.swift
@@ -1,11 +1,11 @@
-// File: AuthContextProvider.swift
-// Purpose: Defines AuthContextProvider component for Cantinarr
+// File: OverseerrAuthContextProvider.swift
+// Purpose: Defines OverseerrAuthContextProvider component for Cantinarr
 
 import AuthenticationServices
 import UIKit
 
 /// Supplies the window for ASWebAuthenticationSession to present in.
-final class AuthContextProvider: NSObject, ASWebAuthenticationPresentationContextProviding {
+final class OverseerrAuthContextProvider: NSObject, ASWebAuthenticationPresentationContextProviding {
     func presentationAnchor(for _: ASWebAuthenticationSession) -> ASPresentationAnchor {
         UIApplication.shared.connectedScenes
             .compactMap { $0 as? UIWindowScene }

--- a/Cantinarr/Core/Helpers/OverseerrPlexSSODelegate.swift
+++ b/Cantinarr/Core/Helpers/OverseerrPlexSSODelegate.swift
@@ -1,0 +1,8 @@
+// File: OverseerrPlexSSODelegate.swift
+// Purpose: Defines OverseerrPlexSSODelegate component for Cantinarr
+
+@MainActor
+/// Delegate for receiving the Plex SSO token after the authentication flow completes.
+protocol OverseerrPlexSSODelegate: AnyObject {
+    func didReceivePlexToken(_ token: String)
+}

--- a/Cantinarr/Core/Helpers/PlexSSODelegate.swift
+++ b/Cantinarr/Core/Helpers/PlexSSODelegate.swift
@@ -1,8 +1,0 @@
-// File: PlexSSODelegate.swift
-// Purpose: Defines PlexSSODelegate component for Cantinarr
-
-@MainActor
-/// Delegate for receiving the Plex SSO token after the authentication flow completes.
-protocol PlexSSODelegate: AnyObject {
-    func didReceivePlexToken(_ token: String)
-}

--- a/Cantinarr/Features/OverseerrUsers/Logic/OverseerrUsersViewModel.swift
+++ b/Cantinarr/Features/OverseerrUsers/Logic/OverseerrUsersViewModel.swift
@@ -64,7 +64,7 @@ class OverseerrUsersViewModel: ObservableObject {
     @Published var movieRecs: [MediaItem] = []
     @Published var tvRecs: [MediaItem] = []
 
-    @Published private(set) var authState: AuthState = .unknown
+    @Published private(set) var authState: OverseerrAuthState = .unknown
     @Published var connectionError: String? = nil
 
     @Published var sessionToken: String? = nil
@@ -85,7 +85,7 @@ class OverseerrUsersViewModel: ObservableObject {
     private func recoverFromAuthFailure() {
         if authState == .unknown { return }
         authState = .unknown
-        Task { await AuthManager.shared.recoverFromAuthFailure() }
+        Task { await OverseerrAuthManager.shared.recoverFromAuthFailure() }
     }
 
     // ─────────────────────────────────────────────
@@ -104,7 +104,7 @@ class OverseerrUsersViewModel: ObservableObject {
     // ─────────────────────────────────────────────
     var service: OverseerrUsersService
     private let settingsKey: String
-    private let authContext = AuthContextProvider()
+    private let authContext = OverseerrAuthContextProvider()
     private var tokenKey: String { "plexAuthToken-\(settingsKey)" }
     private var authCancellable: AnyCancellable?
     let keywordActivatedSubject = PassthroughSubject<Void, Never>()
@@ -120,7 +120,7 @@ class OverseerrUsersViewModel: ObservableObject {
         self.settingsKey = settingsKey
 
         loadSavedFilters()
-        AuthHelper.shared.delegate = self
+        OverseerrAuthHelper.shared.delegate = self
 
         $searchQuery
             .removeDuplicates()
@@ -131,7 +131,7 @@ class OverseerrUsersViewModel: ObservableObject {
             }
             .store(in: &cancellables)
 
-        authCancellable = AuthManager.shared.publisher
+        authCancellable = OverseerrAuthManager.shared.publisher
             .receive(on: RunLoop.main)
             .sink { [weak self] state in
                 guard let self = self else { return }
@@ -150,7 +150,7 @@ class OverseerrUsersViewModel: ObservableObject {
 
     // ─────────────────────────────────────────────
     func onAppear() {
-        Task { await AuthManager.shared.ensureAuthenticated() }
+        Task { await OverseerrAuthManager.shared.ensureAuthenticated() }
     }
 
     private func clearConnectionError() {
@@ -667,7 +667,7 @@ class OverseerrUsersViewModel: ObservableObject {
                 saveTokenToKeychain(authToken)
                 sessionToken = authToken
 
-                await AuthManager.shared.probeSession()
+                await OverseerrAuthManager.shared.probeSession()
 
             } catch {
                 print("🔴 Plex SSO failed: \(error.localizedDescription)")
@@ -731,7 +731,7 @@ class OverseerrUsersViewModel: ObservableObject {
     }
 }
 
-extension OverseerrUsersViewModel: PlexSSODelegate {
+extension OverseerrUsersViewModel: OverseerrPlexSSODelegate {
     func didReceivePlexToken(_ token: String) {
         print("⚠️ Received Plex Token via delegate (Legacy/Unexpected): \(token)")
     }

--- a/Cantinarr/Features/OverseerrUsers/Logic/TrendingViewModel.swift
+++ b/Cantinarr/Features/OverseerrUsers/Logic/TrendingViewModel.swift
@@ -75,7 +75,7 @@ final class TrendingViewModel: ObservableObject {
             }
         } catch is OverseerrError { // More specific: catch OverseerrError
             // Auth errors are primarily handled by OverseerrUsersViewModel's authState
-            // and AuthManager. This VM doesn't need to set connectionError for this.
+            // and OverseerrAuthManager. This VM doesn't need to set connectionError for this.
             loader.cancelLoading()
             print("Trending fetch failed due to OverseerrError.")
         } catch {

--- a/Cantinarr/Features/OverseerrUsers/Networking/OverseerrAPIService.swift
+++ b/Cantinarr/Features/OverseerrUsers/Networking/OverseerrAPIService.swift
@@ -105,7 +105,7 @@ class OverseerrAPIService {
             }
 
             if http.statusCode == 401 || http.statusCode == 403 {
-                await AuthManager.shared.recoverFromAuthFailure()
+                await OverseerrAuthManager.shared.recoverFromAuthFailure()
                 throw OverseerrError.notAuthenticated
             }
 

--- a/Cantinarr/Features/OverseerrUsers/OverseerrUsersHomeEntry.swift
+++ b/Cantinarr/Features/OverseerrUsers/OverseerrUsersHomeEntry.swift
@@ -12,7 +12,7 @@ enum OverseerrTab {
 
 /// Thin wrapper that creates the two view‑models and injects them.
 /// Manages switching between Home and Advanced views for Overseerr via a TabView.
-/// Also handles displaying connection errors for the selected service **based on AuthState**.
+/// Also handles displaying connection errors for the selected service **based on OverseerrAuthState**.
 struct OverseerrUsersHomeEntry: View {
     let settings: OverseerrSettings
     // State to manage the selected tab

--- a/Cantinarr/Features/OverseerrUsers/UI/OverseerrUsersAdvancedView.swift
+++ b/Cantinarr/Features/OverseerrUsers/UI/OverseerrUsersAdvancedView.swift
@@ -261,12 +261,12 @@ struct OverseerrUsersAdvancedView: View {
 // --------------------------------------------------
 //  Plex SSO presentation helper (unchanged)
 // --------------------------------------------------
-class AuthHelper: NSObject, ASWebAuthenticationPresentationContextProviding {
-    static let shared = AuthHelper()
+class OverseerrAuthHelper: NSObject, ASWebAuthenticationPresentationContextProviding {
+    static let shared = OverseerrAuthHelper()
     override private init() {}
 
     private var session: ASWebAuthenticationSession?
-    weak var delegate: PlexSSODelegate?
+    weak var delegate: OverseerrPlexSSODelegate?
 
     func startPlexLogin(url: URL) {
         let s = ASWebAuthenticationSession(


### PR DESCRIPTION
## Summary
- rename AuthManager to OverseerrAuthManager
- rename AuthState to OverseerrAuthState
- rename Overseerr-related helpers and delegate protocols
- update references to new names

## Testing
- `bash Scripts/lint.sh` *(fails: Could not read configuration)*