### PR TITLE
Switch settings editor to form inputs

### DIFF
--- a/Cantinarr/Features/Settings/UI/ServiceEditorView.swift
+++ b/Cantinarr/Features/Settings/UI/ServiceEditorView.swift
@@ -9,14 +9,25 @@ struct ServiceEditorView: View {
     let onSave: (ServiceDraft) -> Void
     @Environment(\.dismiss) private var dismiss
 
+    // Typed configurations for supported service kinds
+    @State private var radarrSettings: RadarrSettings =
+        RadarrSettings(host: "", apiKey: "")
+    @State private var overseerrSettings: OverseerrSettings =
+        OverseerrSettings(host: "", port: nil)
+
     // ───────── Validation helpers
     private var isDisplayNameOK: Bool {
         !draft.displayName.trimmingCharacters(in: .whitespaces).isEmpty
     }
 
-    private var isJSONValid: Bool {
-        guard let data = draft.configurationJSON.data(using: .utf8) else { return false }
-        return (try? JSONSerialization.jsonObject(with: data)) != nil
+    private var isConfigurationValid: Bool {
+        switch draft.kind {
+        case .radarr:
+            return !radarrSettings.host.trimmingCharacters(in: .whitespaces).isEmpty &&
+                !radarrSettings.apiKey.isEmpty
+        case .overseerrUsers:
+            return !overseerrSettings.host.trimmingCharacters(in: .whitespaces).isEmpty
+        }
     }
 
     init(draft: ServiceDraft,
@@ -24,6 +35,20 @@ struct ServiceEditorView: View {
     {
         _draft = State(initialValue: draft)
         self.onSave = onSave
+
+        if draft.kind == .radarr,
+           let data = draft.configurationJSON.data(using: .utf8),
+           let settings = try? JSONDecoder().decode(RadarrSettings.self, from: data)
+        {
+            _radarrSettings = State(initialValue: settings)
+        }
+
+        if draft.kind == .overseerrUsers,
+           let data = draft.configurationJSON.data(using: .utf8),
+           let settings = try? JSONDecoder().decode(OverseerrSettings.self, from: data)
+        {
+            _overseerrSettings = State(initialValue: settings)
+        }
     }
 
     var body: some View {
@@ -41,18 +66,43 @@ struct ServiceEditorView: View {
                 TextField("e.g. “Overseerr – Basement Plex”", text: $draft.displayName)
             }
 
-            Section("Configuration (JSON)") {
-                ZStack {
-                    TextEditor(text: $draft.configurationJSON)
-                        .font(.system(.body, design: .monospaced))
-                        .frame(minHeight: 160)
-                        // Red border if JSON invalid
-                        .overlay(
-                            RoundedRectangle(cornerRadius: 8)
-                                .stroke(isJSONValid ? Color.clear : Color.red, lineWidth: 2)
-                        )
-                }
+        Section("Configuration") {
+            switch draft.kind {
+            case .radarr:
+                TextField("Host", text: $radarrSettings.host)
+                    .textInputAutocapitalization(.none)
+                    .autocorrectionDisabled()
+                TextField(
+                    "Port",
+                    text: Binding(
+                        get: { radarrSettings.port ?? "" },
+                        set: { radarrSettings.port = $0.isEmpty ? nil : $0 }
+                    )
+                )
+                Toggle("Use SSL", isOn: $radarrSettings.useSSL)
+                TextField(
+                    "URL Base",
+                    text: Binding(
+                        get: { radarrSettings.urlBase ?? "" },
+                        set: { radarrSettings.urlBase = $0.isEmpty ? nil : $0 }
+                    )
+                )
+                SecureField("API Key", text: $radarrSettings.apiKey)
+                Toggle("Primary Instance", isOn: $radarrSettings.isPrimary)
+            case .overseerrUsers:
+                TextField("Host", text: $overseerrSettings.host)
+                    .textInputAutocapitalization(.none)
+                    .autocorrectionDisabled()
+                TextField(
+                    "Port",
+                    text: Binding(
+                        get: { overseerrSettings.port ?? "" },
+                        set: { overseerrSettings.port = $0.isEmpty ? nil : $0 }
+                    )
+                )
+                Toggle("Use SSL", isOn: $overseerrSettings.useSSL)
             }
+        }
         }
         .navigationTitle(draft.displayName.isEmpty ? "New Service"
             : "Edit Service")
@@ -60,10 +110,9 @@ struct ServiceEditorView: View {
             ToolbarItem(placement: .confirmationAction) {
                 Button("Save") {
                     var outgoing = draft
-                    if draft.kind == .radarr,
-                       let data = draft.configurationJSON.data(using: .utf8),
-                       let settings = try? JSONDecoder().decode(RadarrSettings.self, from: data)
-                    {
+                    switch draft.kind {
+                    case .radarr:
+                        let settings = radarrSettings
                         if let apiData = settings.apiKey.data(using: .utf8) {
                             KeychainHelper.save(
                                 key: RadarrSettings.keychainKey(host: settings.host, port: settings.port),
@@ -75,11 +124,18 @@ struct ServiceEditorView: View {
                         {
                             outgoing.configurationJSON = jsonString
                         }
+                    case .overseerrUsers:
+                        let settings = overseerrSettings
+                        if let sanitized = try? JSONEncoder().encode(settings),
+                           let jsonString = String(data: sanitized, encoding: .utf8)
+                        {
+                            outgoing.configurationJSON = jsonString
+                        }
                     }
                     onSave(outgoing)
                     dismiss()
                 }
-                .disabled(!(isDisplayNameOK && isJSONValid))
+                .disabled(!(isDisplayNameOK && isConfigurationValid))
             }
             ToolbarItem(placement: .cancellationAction) {
                 Button("Cancel") { dismiss() }


### PR DESCRIPTION
## Summary
- replace JSON text editor with dynamic form fields for Radarr and Overseerr services
- save typed configuration back to JSON

## Testing
- `git status --short`