### PR TITLE
Fix filter property references

### DIFF
--- a/Cantinarr/Features/OverseerrUsers/Logic/FilterManager.swift
+++ b/Cantinarr/Features/OverseerrUsers/Logic/FilterManager.swift
@@ -1,0 +1,52 @@
+// File: FilterManager.swift
+// Purpose: Manages discover filter state for OverseerrUsers
+
+import Foundation
+import Combine
+
+@MainActor
+final class FilterManager: ObservableObject {
+    @Published var selectedMedia: MediaType = .movie {
+        didSet { if oldValue != selectedMedia { save() } }
+    }
+    @Published var selectedProviders: Set<Int> = [] {
+        didSet { if oldValue != selectedProviders { save() } }
+    }
+    @Published var selectedGenres: Set<Int> = [] {
+        didSet { if oldValue != selectedGenres { save() } }
+    }
+    @Published var activeKeywordIDs: Set<Int> = []
+
+    private let settingsKey: String
+    private var storageKey: String { "discoverFilters-\(settingsKey)" }
+
+    init(settingsKey: String) {
+        self.settingsKey = settingsKey
+    }
+
+    func load() {
+        guard let data = UserDefaults.standard.data(forKey: storageKey),
+              let saved = try? JSONDecoder().decode(SavedFilters.self, from: data)
+        else { return }
+        selectedMedia = saved.mediaType
+        selectedProviders = Set(saved.providerIds)
+        selectedGenres = Set(saved.genreIds)
+    }
+
+    func save() {
+        let saved = SavedFilters(
+            mediaType: selectedMedia,
+            providerIds: Array(selectedProviders),
+            genreIds: Array(selectedGenres)
+        )
+        if let data = try? JSONEncoder().encode(saved) {
+            UserDefaults.standard.set(data, forKey: storageKey)
+        }
+    }
+
+    private struct SavedFilters: Codable {
+        let mediaType: MediaType
+        let providerIds: [Int]
+        let genreIds: [Int]
+    }
+}

--- a/Cantinarr/Features/OverseerrUsers/UI/NetworkSelectionView.swift
+++ b/Cantinarr/Features/OverseerrUsers/UI/NetworkSelectionView.swift
@@ -14,7 +14,7 @@ struct NetworkSelectionView: View {
                 HStack {
                     Text(provider.name) // network name
                     Spacer()
-                    if vm.selectedProviders.contains(provider.id) {
+                    if vm.filters.selectedProviders.contains(provider.id) {
                         Image(systemName: "checkmark") // show checkmark if selected
                             .foregroundColor(.accentColor)
                     }
@@ -22,10 +22,10 @@ struct NetworkSelectionView: View {
                 .contentShape(Rectangle()) // make full row tappable
                 .onTapGesture {
                     // toggle selection
-                    if vm.selectedProviders.contains(provider.id) {
-                        vm.selectedProviders.remove(provider.id)
+                    if vm.filters.selectedProviders.contains(provider.id) {
+                        vm.filters.selectedProviders.remove(provider.id)
                     } else {
-                        vm.selectedProviders.insert(provider.id)
+                        vm.filters.selectedProviders.insert(provider.id)
                     }
                 }
             }

--- a/Cantinarr/Features/OverseerrUsers/UI/OverseerrUsersAdvancedView.swift
+++ b/Cantinarr/Features/OverseerrUsers/UI/OverseerrUsersAdvancedView.swift
@@ -74,7 +74,7 @@ struct OverseerrUsersAdvancedView: View {
             VStack(alignment: .leading, spacing: 16) {
                 if vm.searchQuery.isEmpty {
                     // Movies / TV picker
-                    Picker("Media", selection: $vm.selectedMedia) {
+                    Picker("Media", selection: $vm.filters.selectedMedia) {
                         ForEach(MediaType.allCases
                             .filter { $0 != .unknown && $0 != .person && $0 != .collection })
                         { mt in
@@ -86,7 +86,7 @@ struct OverseerrUsersAdvancedView: View {
                     .padding(.horizontal)
 
                     // Active keyword pillszzz
-                    if !vm.activeKeywordIDs.isEmpty {
+                    if !vm.filters.activeKeywordIDs.isEmpty {
                         ActiveKeywordsView()
                             .environmentObject(vm)
                             .padding(.top, 4)
@@ -149,7 +149,7 @@ struct OverseerrUsersAdvancedView: View {
                     }
                     // Only suggestions not already active
                     let filteredSuggestions = vm.keywordSuggestions
-                        .filter { !vm.activeKeywordIDs.contains($0.id) }
+                        .filter { !vm.filters.activeKeywordIDs.contains($0.id) }
 
                     if vm.isLoadingKeywords || !filteredSuggestions.isEmpty {
                         Text("Search by Keyword")

--- a/Cantinarr/Features/OverseerrUsers/UI/OverseerrUsersHomeView.swift
+++ b/Cantinarr/Features/OverseerrUsers/UI/OverseerrUsersHomeView.swift
@@ -220,7 +220,7 @@ struct OverseerrUsersHomeView: View {
     private var searchResultsSection: some View {
         // Filter out suggestions that are already active keywords
         let filteredSuggestions = overseerrUsersVM.keywordSuggestions
-            .filter { !overseerrUsersVM.activeKeywordIDs.contains($0.id) }
+            .filter { !overseerrUsersVM.filters.activeKeywordIDs.contains($0.id) }
 
         Group {
             // Search Results for Movies/TV


### PR DESCRIPTION
## Summary
- use `FilterManager` properties inside Overseerr user views
- bind AdvancedView picker to new manager state
- update provider selection to modify manager

## Testing
- `swiftc -emit-module -parse-as-library -o /dev/null $(find Cantinarr -name '*.swift')` *(fails: no such module 'SwiftUI')*
