### PR TITLE
Refactor Overseerr filter handling

### DIFF
--- a/Cantinarr/Features/OverseerrUsers/Logic/FilterManager.swift
+++ b/Cantinarr/Features/OverseerrUsers/Logic/FilterManager.swift
@@ -6,22 +6,33 @@ import Combine
 
 @MainActor
 final class FilterManager: ObservableObject {
-    @Published var selectedMedia: MediaType = .movie {
-        didSet { if oldValue != selectedMedia { save() } }
-    }
-    @Published var selectedProviders: Set<Int> = [] {
-        didSet { if oldValue != selectedProviders { save() } }
-    }
-    @Published var selectedGenres: Set<Int> = [] {
-        didSet { if oldValue != selectedGenres { save() } }
-    }
+    @Published var selectedMedia: MediaType = .movie
+    @Published var selectedProviders: Set<Int> = []
+    @Published var selectedGenres: Set<Int> = []
     @Published var activeKeywordIDs: Set<Int> = []
+
+    private var cancellables = Set<AnyCancellable>()
 
     private let settingsKey: String
     private var storageKey: String { "discoverFilters-\(settingsKey)" }
 
     init(settingsKey: String) {
         self.settingsKey = settingsKey
+
+        $selectedMedia
+            .dropFirst()
+            .sink { [weak self] _ in self?.save() }
+            .store(in: &cancellables)
+
+        $selectedProviders
+            .dropFirst()
+            .sink { [weak self] _ in self?.save() }
+            .store(in: &cancellables)
+
+        $selectedGenres
+            .dropFirst()
+            .sink { [weak self] _ in self?.save() }
+            .store(in: &cancellables)
     }
 
     func load() {

--- a/Cantinarr/Features/OverseerrUsers/Logic/OverseerrUsersViewModel.swift
+++ b/Cantinarr/Features/OverseerrUsers/Logic/OverseerrUsersViewModel.swift
@@ -44,6 +44,22 @@ class OverseerrUsersViewModel: ObservableObject {
         controller.objectWillChange
             .sink { [weak self] _ in self?.objectWillChange.send() }
             .store(in: &cancellables)
+
+        controller.$results
+            .assign(to: \OverseerrUsersViewModel.results, on: self)
+            .store(in: &cancellables)
+        controller.$keywordSuggestions
+            .assign(to: \OverseerrUsersViewModel.keywordSuggestions, on: self)
+            .store(in: &cancellables)
+        controller.$activeKeywords
+            .assign(to: \OverseerrUsersViewModel.activeKeywords, on: self)
+            .store(in: &cancellables)
+        controller.$movieRecs
+            .assign(to: \OverseerrUsersViewModel.movieRecs, on: self)
+            .store(in: &cancellables)
+        controller.$tvRecs
+            .assign(to: \OverseerrUsersViewModel.tvRecs, on: self)
+            .store(in: &cancellables)
         return controller
     }()
 
@@ -52,27 +68,15 @@ class OverseerrUsersViewModel: ObservableObject {
 
     @Published var sessionToken: String? = nil
     @Published private(set) var isLoading: Bool = false // Discover loading
-    var searchQuery: String { get { searchController.searchQuery } set { searchController.searchQuery = newValue } }
-    var results: [MediaItem] {
-        get { searchController.results }
-        set { searchController.results = newValue }
+    var searchQuery: String {
+        get { searchController.searchQuery }
+        set { searchController.searchQuery = newValue }
     }
-    var keywordSuggestions: [OverseerrAPIService.Keyword] {
-        get { searchController.keywordSuggestions }
-        set { searchController.keywordSuggestions = newValue }
-    }
-    var activeKeywords: [OverseerrAPIService.Keyword] {
-        get { searchController.activeKeywords }
-        set { searchController.activeKeywords = newValue }
-    }
-    var movieRecs: [MediaItem] {
-        get { searchController.movieRecs }
-        set { searchController.movieRecs = newValue }
-    }
-    var tvRecs: [MediaItem] {
-        get { searchController.tvRecs }
-        set { searchController.tvRecs = newValue }
-    }
+    @Published private(set) var results: [MediaItem] = []
+    @Published private(set) var keywordSuggestions: [OverseerrAPIService.Keyword] = []
+    @Published private(set) var activeKeywords: [OverseerrAPIService.Keyword] = []
+    @Published private(set) var movieRecs: [MediaItem] = []
+    @Published private(set) var tvRecs: [MediaItem] = []
     var isLoadingSearch: Bool { searchController.isLoadingSearch }
     var isLoadingKeywords: Bool { searchController.isLoadingKeywords }
     var isLoadingMovieRecs: Bool { searchController.isLoadingMovieRecs }
@@ -243,7 +247,7 @@ class OverseerrUsersViewModel: ObservableObject {
         guard !isLoading else { return }
         if reset {
             loader.reset()
-            results.removeAll() // Clear previous results (could be search or discover)
+            searchController.results.removeAll() // Clear previous results (could be search or discover)
             clearConnectionError()
         }
 
@@ -299,8 +303,8 @@ class OverseerrUsersViewModel: ObservableObject {
             }
 
             // Merge the new page results with existing content
-            if loader.page == 1 { results = fetchedItems }
-            else { results.append(contentsOf: fetchedItems) }
+            if loader.page == 1 { searchController.results = fetchedItems }
+            else { searchController.results.append(contentsOf: fetchedItems) }
             loader.endLoading(next: responseTotalPages)
 
             if !watchProviders.isEmpty { clearConnectionError() }


### PR DESCRIPTION
## Summary
- convert `FilterManager` property observers to Combine
- expose search result properties as `@Published private(set)` in `OverseerrUsersViewModel`
- keep `searchController` results in sync via Combine subscriptions

## Testing
- `swiftc -parse Cantinarr/Features/OverseerrUsers/Logic/OverseerrUsersViewModel.swift`
- `swiftc -parse Cantinarr/Features/OverseerrUsers/Logic/FilterManager.swift`
- `swiftc -parse Cantinarr/Features/OverseerrUsers/Logic/SearchController.swift`
