### PR TITLE
Refine search state synchronization

### DIFF
--- a/Cantinarr/Features/OverseerrUsers/Logic/FilterManager.swift
+++ b/Cantinarr/Features/OverseerrUsers/Logic/FilterManager.swift
@@ -6,22 +6,33 @@ import Combine
 
 @MainActor
 final class FilterManager: ObservableObject {
-    @Published var selectedMedia: MediaType = .movie {
-        didSet { if oldValue != selectedMedia { save() } }
-    }
-    @Published var selectedProviders: Set<Int> = [] {
-        didSet { if oldValue != selectedProviders { save() } }
-    }
-    @Published var selectedGenres: Set<Int> = [] {
-        didSet { if oldValue != selectedGenres { save() } }
-    }
+    @Published var selectedMedia: MediaType = .movie
+    @Published var selectedProviders: Set<Int> = []
+    @Published var selectedGenres: Set<Int> = []
     @Published var activeKeywordIDs: Set<Int> = []
+
+    private var cancellables = Set<AnyCancellable>()
 
     private let settingsKey: String
     private var storageKey: String { "discoverFilters-\(settingsKey)" }
 
     init(settingsKey: String) {
         self.settingsKey = settingsKey
+
+        $selectedMedia
+            .dropFirst()
+            .sink { [weak self] _ in self?.save() }
+            .store(in: &cancellables)
+
+        $selectedProviders
+            .dropFirst()
+            .sink { [weak self] _ in self?.save() }
+            .store(in: &cancellables)
+
+        $selectedGenres
+            .dropFirst()
+            .sink { [weak self] _ in self?.save() }
+            .store(in: &cancellables)
     }
 
     func load() {

--- a/Cantinarr/Features/OverseerrUsers/Logic/OverseerrUsersViewModel.swift
+++ b/Cantinarr/Features/OverseerrUsers/Logic/OverseerrUsersViewModel.swift
@@ -44,6 +44,31 @@ class OverseerrUsersViewModel: ObservableObject {
         controller.objectWillChange
             .sink { [weak self] _ in self?.objectWillChange.send() }
             .store(in: &cancellables)
+        controller.$results
+            .dropFirst()
+            .receive(on: RunLoop.main)
+            .assign(to: \OverseerrUsersViewModel.results, on: self)
+            .store(in: &cancellables)
+        controller.$keywordSuggestions
+            .dropFirst()
+            .receive(on: RunLoop.main)
+            .assign(to: \OverseerrUsersViewModel.keywordSuggestions, on: self)
+            .store(in: &cancellables)
+        controller.$activeKeywords
+            .dropFirst()
+            .receive(on: RunLoop.main)
+            .assign(to: \OverseerrUsersViewModel.activeKeywords, on: self)
+            .store(in: &cancellables)
+        controller.$movieRecs
+            .dropFirst()
+            .receive(on: RunLoop.main)
+            .assign(to: \OverseerrUsersViewModel.movieRecs, on: self)
+            .store(in: &cancellables)
+        controller.$tvRecs
+            .dropFirst()
+            .receive(on: RunLoop.main)
+            .assign(to: \OverseerrUsersViewModel.tvRecs, on: self)
+            .store(in: &cancellables)
         return controller
     }()
 
@@ -52,27 +77,15 @@ class OverseerrUsersViewModel: ObservableObject {
 
     @Published var sessionToken: String? = nil
     @Published private(set) var isLoading: Bool = false // Discover loading
-    var searchQuery: String { get { searchController.searchQuery } set { searchController.searchQuery = newValue } }
-    var results: [MediaItem] {
-        get { searchController.results }
-        set { searchController.results = newValue }
+    var searchQuery: String {
+        get { searchController.searchQuery }
+        set { searchController.searchQuery = newValue }
     }
-    var keywordSuggestions: [OverseerrAPIService.Keyword] {
-        get { searchController.keywordSuggestions }
-        set { searchController.keywordSuggestions = newValue }
-    }
-    var activeKeywords: [OverseerrAPIService.Keyword] {
-        get { searchController.activeKeywords }
-        set { searchController.activeKeywords = newValue }
-    }
-    var movieRecs: [MediaItem] {
-        get { searchController.movieRecs }
-        set { searchController.movieRecs = newValue }
-    }
-    var tvRecs: [MediaItem] {
-        get { searchController.tvRecs }
-        set { searchController.tvRecs = newValue }
-    }
+    @Published private(set) var results: [MediaItem] = []
+    @Published private(set) var keywordSuggestions: [OverseerrAPIService.Keyword] = []
+    @Published private(set) var activeKeywords: [OverseerrAPIService.Keyword] = []
+    @Published private(set) var movieRecs: [MediaItem] = []
+    @Published private(set) var tvRecs: [MediaItem] = []
     var isLoadingSearch: Bool { searchController.isLoadingSearch }
     var isLoadingKeywords: Bool { searchController.isLoadingKeywords }
     var isLoadingMovieRecs: Bool { searchController.isLoadingMovieRecs }
@@ -243,7 +256,7 @@ class OverseerrUsersViewModel: ObservableObject {
         guard !isLoading else { return }
         if reset {
             loader.reset()
-            results.removeAll() // Clear previous results (could be search or discover)
+            searchController.results.removeAll() // Clear previous results (could be search or discover)
             clearConnectionError()
         }
 
@@ -299,8 +312,8 @@ class OverseerrUsersViewModel: ObservableObject {
             }
 
             // Merge the new page results with existing content
-            if loader.page == 1 { results = fetchedItems }
-            else { results.append(contentsOf: fetchedItems) }
+            if loader.page == 1 { searchController.results = fetchedItems }
+            else { searchController.results.append(contentsOf: fetchedItems) }
             loader.endLoading(next: responseTotalPages)
 
             if !watchProviders.isEmpty { clearConnectionError() }

--- a/Cantinarr/Features/OverseerrUsers/UI/OverseerrUsersAdvancedView.swift
+++ b/Cantinarr/Features/OverseerrUsers/UI/OverseerrUsersAdvancedView.swift
@@ -236,8 +236,7 @@ struct OverseerrUsersAdvancedView: View {
                     .onChange(of: searchText) { _, newValue in
                         if !newValue.isEmpty {
                             // 1) clear out stale cards immediately
-                            vm.results.removeAll()
-                            vm.keywordSuggestions.removeAll()
+                            vm.clearSearchResultsAndRecs()
                             // 2) show shimmer immediately
                             isSearchLoadingLocal = true
                         }


### PR DESCRIPTION
## Summary
- update advanced search view to clear results using helper
- subscribe to SearchController updates with Combine and drop initial value

## Testing
- `swiftc -parse Cantinarr/Features/OverseerrUsers/Logic/FilterManager.swift`
- `swiftc -parse Cantinarr/Features/OverseerrUsers/Logic/OverseerrUsersViewModel.swift`
- `swiftc -parse Cantinarr/Features/OverseerrUsers/Logic/SearchController.swift`
- `swiftc -parse Cantinarr/Features/OverseerrUsers/UI/OverseerrUsersAdvancedView.swift`
