### PR TITLE
Remove filter persistence and restrict state setters

### DIFF
--- a/Cantinarr/Features/OverseerrUsers/Logic/FilterManager.swift
+++ b/Cantinarr/Features/OverseerrUsers/Logic/FilterManager.swift
@@ -6,47 +6,10 @@ import Combine
 
 @MainActor
 final class FilterManager: ObservableObject {
-    @Published var selectedMedia: MediaType = .movie {
-        didSet { if oldValue != selectedMedia { save() } }
-    }
-    @Published var selectedProviders: Set<Int> = [] {
-        didSet { if oldValue != selectedProviders { save() } }
-    }
-    @Published var selectedGenres: Set<Int> = [] {
-        didSet { if oldValue != selectedGenres { save() } }
-    }
+    @Published var selectedMedia: MediaType = .movie
+    @Published var selectedProviders: Set<Int> = []
+    @Published var selectedGenres: Set<Int> = []
     @Published var activeKeywordIDs: Set<Int> = []
 
-    private let settingsKey: String
-    private var storageKey: String { "discoverFilters-\(settingsKey)" }
-
-    init(settingsKey: String) {
-        self.settingsKey = settingsKey
-    }
-
-    func load() {
-        guard let data = UserDefaults.standard.data(forKey: storageKey),
-              let saved = try? JSONDecoder().decode(SavedFilters.self, from: data)
-        else { return }
-        selectedMedia = saved.mediaType
-        selectedProviders = Set(saved.providerIds)
-        selectedGenres = Set(saved.genreIds)
-    }
-
-    func save() {
-        let saved = SavedFilters(
-            mediaType: selectedMedia,
-            providerIds: Array(selectedProviders),
-            genreIds: Array(selectedGenres)
-        )
-        if let data = try? JSONEncoder().encode(saved) {
-            UserDefaults.standard.set(data, forKey: storageKey)
-        }
-    }
-
-    private struct SavedFilters: Codable {
-        let mediaType: MediaType
-        let providerIds: [Int]
-        let genreIds: [Int]
-    }
+    init() {}
 }

--- a/Cantinarr/Features/OverseerrUsers/Logic/OverseerrUsersViewModel.swift
+++ b/Cantinarr/Features/OverseerrUsers/Logic/OverseerrUsersViewModel.swift
@@ -53,23 +53,23 @@ class OverseerrUsersViewModel: ObservableObject {
     @Published var sessionToken: String? = nil
     @Published private(set) var isLoading: Bool = false // Discover loading
     var searchQuery: String { get { searchController.searchQuery } set { searchController.searchQuery = newValue } }
-    var results: [MediaItem] {
+    private(set) var results: [MediaItem] {
         get { searchController.results }
         set { searchController.results = newValue }
     }
-    var keywordSuggestions: [OverseerrAPIService.Keyword] {
+    private(set) var keywordSuggestions: [OverseerrAPIService.Keyword] {
         get { searchController.keywordSuggestions }
         set { searchController.keywordSuggestions = newValue }
     }
-    var activeKeywords: [OverseerrAPIService.Keyword] {
+    private(set) var activeKeywords: [OverseerrAPIService.Keyword] {
         get { searchController.activeKeywords }
         set { searchController.activeKeywords = newValue }
     }
-    var movieRecs: [MediaItem] {
+    private(set) var movieRecs: [MediaItem] {
         get { searchController.movieRecs }
         set { searchController.movieRecs = newValue }
     }
-    var tvRecs: [MediaItem] {
+    private(set) var tvRecs: [MediaItem] {
         get { searchController.tvRecs }
         set { searchController.tvRecs = newValue }
     }
@@ -117,14 +117,13 @@ class OverseerrUsersViewModel: ObservableObject {
         // Added callback
         self.service = service
         self.settingsKey = settingsKey
-        self.filters = FilterManager(settingsKey: settingsKey)
+        self.filters = FilterManager()
         self.plexSSOHandler = PlexSSOHandler(
             service: service,
             settingsKey: settingsKey,
             authContext: authContext
         )
 
-        filters.load()
         if let savedToken = plexSSOHandler.loadTokenFromKeychain() {
             sessionToken = savedToken
             Task {

--- a/Cantinarr/Features/OverseerrUsers/UI/OverseerrUsersAdvancedView.swift
+++ b/Cantinarr/Features/OverseerrUsers/UI/OverseerrUsersAdvancedView.swift
@@ -236,8 +236,7 @@ struct OverseerrUsersAdvancedView: View {
                     .onChange(of: searchText) { _, newValue in
                         if !newValue.isEmpty {
                             // 1) clear out stale cards immediately
-                            vm.results.removeAll()
-                            vm.keywordSuggestions.removeAll()
+                            vm.clearSearchResultsAndRecs()
                             // 2) show shimmer immediately
                             isSearchLoadingLocal = true
                         }


### PR DESCRIPTION
## Summary
- prevent saving FilterManager values to disk so filters only persist for the session
- use `private(set)` on search result properties in OverseerrUsersViewModel
- replace direct results mutation in OverseerrUsersAdvancedView with view model method

## Testing
- `swiftc -parse Cantinarr/Features/OverseerrUsers/Logic/OverseerrUsersViewModel.swift Cantinarr/Features/OverseerrUsers/Logic/FilterManager.swift Cantinarr/Features/OverseerrUsers/UI/OverseerrUsersAdvancedView.swift`
