### PR TITLE
Refactor MediaDetailView

### DIFF
--- a/Cantinarr/Features/MediaDetail/UI/MediaHeaderView.swift
+++ b/Cantinarr/Features/MediaDetail/UI/MediaHeaderView.swift
@@ -1,0 +1,125 @@
+import SwiftUI
+import NukeUI
+
+/// Header displaying poster, title and action buttons.
+struct MediaHeaderView: View {
+    let posterURL: URL?
+    let backdropURL: URL?
+    let title: String
+    let availability: MediaAvailability
+    let trailerVideoID: String?
+    let youtubeEmbedURL: URL?
+    @Binding var showTrailerPlayer: Bool
+    @Binding var showReport: Bool
+
+    var body: some View {
+        ZStack(alignment: .bottomLeading) {
+            LinearGradient(colors: [Color.black.opacity(0.6), Color.clear],
+                           startPoint: .bottom, endPoint: .top)
+            HStack(alignment: .bottom, spacing: 16) {
+                if let url = posterURL {
+                    LazyImage(url: url) { state in
+                        state.image?.resizable()
+                            .scaledToFill()
+                            .frame(width: 120, height: 180)
+                            .cornerRadius(12)
+                            .shadow(radius: 5)
+                    }
+                }
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(title)
+                        .font(.title.weight(.semibold))
+                        .lineLimit(3)
+                        .truncationMode(.tail)
+                    Label(availability.label, systemImage: "circle.fill")
+                        .font(.caption)
+                        .foregroundColor(.white)
+                        .padding(6)
+                        .background(availability.tint)
+                        .cornerRadius(6)
+                    buttonRow
+                }
+                Spacer()
+            }
+            .padding()
+        }
+        .background {
+            if let url = backdropURL {
+                LazyImage(url: url) { state in
+                    state.image?.resizable()
+                        .scaledToFill()
+                        .overlay(Color.black.opacity(0.25))
+                }
+            }
+        }
+        .clipped()
+    }
+
+    @ViewBuilder private var buttonRow: some View {
+        VStack(alignment: .center, spacing: 10) {
+            HStack(spacing: 12) {
+                watchTrailerBtn.frame(maxWidth: .infinity)
+            }
+            if availability == .available || availability == .partiallyAvailable {
+                reportBtn
+            }
+        }
+    }
+
+    private var watchTrailerBtn: some View {
+        Button {
+            if trailerVideoID != nil {
+                showTrailerPlayer = true
+            } else {
+                guard !title.isEmpty,
+                      let query = "\(title) trailer".addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed),
+                      let url = URL(string: "https://www.youtube.com/results?search_query=\(query)")
+                else { return }
+                UIApplication.shared.open(url)
+            }
+        } label: {
+            Label("Watch Trailer", systemImage: "video")
+        }
+        .buttonStyle(.bordered)
+        .sheet(isPresented: $showTrailerPlayer) {
+            if let url = youtubeEmbedURL {
+                TrailerPlayerView(url: url)
+            } else {
+                VStack {
+                    Text("Trailer is unavailable at the moment.")
+                    Button("Dismiss") { showTrailerPlayer = false }.padding()
+                }
+            }
+        }
+    }
+
+    private var reportBtn: some View {
+        Button { showReport.toggle() } label: {
+            Image(systemName: "exclamationmark.triangle.fill")
+        }
+        .buttonStyle(.bordered)
+        .tint(.yellow)
+    }
+}
+
+#if DEBUG
+struct MediaHeaderView_Previews: PreviewProvider {
+    @State static var showTrailer = false
+    @State static var showReport = false
+
+    static var previews: some View {
+        MediaHeaderView(
+            posterURL: URL(string: "https://example.com/poster.jpg"),
+            backdropURL: URL(string: "https://example.com/backdrop.jpg"),
+            title: "Example Movie Title That Is Quite Long",
+            availability: .available,
+            trailerVideoID: "abc123",
+            youtubeEmbedURL: URL(string: "https://www.youtube.com/embed/abc123"),
+            showTrailerPlayer: $showTrailer,
+            showReport: $showReport
+        )
+        .preferredColorScheme(.dark)
+    }
+}
+#endif
+

--- a/Cantinarr/Features/MediaDetail/UI/MediaOverviewView.swift
+++ b/Cantinarr/Features/MediaDetail/UI/MediaOverviewView.swift
@@ -1,0 +1,22 @@
+import SwiftUI
+
+/// Displays the overview text for a media item.
+struct MediaOverviewView: View {
+    let overview: String
+
+    var body: some View {
+        Text(overview)
+            .font(.body)
+    }
+}
+
+#if DEBUG
+struct MediaOverviewView_Previews: PreviewProvider {
+    static var previews: some View {
+        MediaOverviewView(overview: "This is a mock overview of the movie used for SwiftUI previews.")
+            .padding()
+            .previewLayout(.sizeThatFits)
+    }
+}
+#endif
+

--- a/Cantinarr/Features/MediaDetail/UI/MediaTaglineView.swift
+++ b/Cantinarr/Features/MediaDetail/UI/MediaTaglineView.swift
@@ -1,0 +1,37 @@
+import SwiftUI
+
+/// Preference key used to report the tagline height up the view hierarchy.
+struct TaglineHeightKey: PreferenceKey {
+    static var defaultValue: CGFloat = .zero
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        value = nextValue()
+    }
+}
+
+/// Displays the media tagline and reports its height with a preference.
+struct MediaTaglineView: View {
+    let tagline: String
+
+    var body: some View {
+        Text(tagline)
+            .font(.title3.italic())
+            .opacity(0.8)
+            .background(
+                GeometryReader { g in
+                    Color.clear.preference(key: TaglineHeightKey.self,
+                                            value: g.size.height)
+                }
+            )
+    }
+}
+
+#if DEBUG
+struct MediaTaglineView_Previews: PreviewProvider {
+    static var previews: some View {
+        MediaTaglineView(tagline: "A thrilling tale of adventure.")
+            .padding()
+            .previewLayout(.sizeThatFits)
+    }
+}
+#endif
+

--- a/Cantinarr/Features/MediaDetail/UI/SeasonGridView.swift
+++ b/Cantinarr/Features/MediaDetail/UI/SeasonGridView.swift
@@ -1,0 +1,48 @@
+import SwiftUI
+
+/// Displays a grid of seasons for a TV show.
+struct SeasonGridView: View {
+    let seasons: [OverseerrAPIService.Season]
+    let requestAction: () -> Void
+
+    var body: some View {
+        LazyVGrid(columns: [GridItem(.adaptive(minimum: 100), spacing: 12)]) {
+            ForEach(seasons) { s in
+                VStack(spacing: 4) {
+                    Text("Season \(s.seasonNumber)")
+                    Text("\(s.episodeCount) eps")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                    Label(s.mediaInfo?.status.label ?? "–", systemImage: "circle.fill")
+                        .font(.caption2)
+                        .foregroundColor(.white)
+                        .padding(4)
+                        .background(s.mediaInfo?.status.tint ?? .gray)
+                        .cornerRadius(4)
+                }
+                .padding(8)
+                .background(
+                    Material.ultraThin,
+                    in: RoundedRectangle(cornerRadius: 8)
+                )
+                .onTapGesture {
+                    if s.mediaInfo?.status != .available {
+                        requestAction()
+                    }
+                }
+            }
+        }
+    }
+}
+
+#if DEBUG
+struct SeasonGridView_Previews: PreviewProvider {
+    static var previews: some View {
+        let mockSeason = OverseerrAPIService.Season(id: 1, seasonNumber: 1, episodeCount: 8, mediaInfo: .init(status: .available, plexUrl: nil))
+        SeasonGridView(seasons: [mockSeason], requestAction: {})
+            .padding()
+            .previewLayout(.sizeThatFits)
+    }
+}
+#endif
+


### PR DESCRIPTION
## Summary
- break out `MediaHeaderView` and supporting subviews
- update `MediaDetailView` to use the new components
- add SwiftUI previews for each component
- fix tagline visibility check

## Testing
- `git status --short`
