### PR TITLE
Refactor Radarr detail view components

### DIFF
--- a/Cantinarr/Features/Radarr/UI/ActionButtonsSection.swift
+++ b/Cantinarr/Features/Radarr/UI/ActionButtonsSection.swift
@@ -1,0 +1,99 @@
+import SwiftUI
+
+/// Action buttons allowing monitoring toggles, search and deletion.
+struct ActionButtonsSection: View {
+    let movie: RadarrMovie
+    let toggleMonitoring: () async -> Void
+    let triggerSearch: () async -> Void
+    let deleteMovie: (_ alsoDeleteFiles: Bool) async -> Void
+
+    @State private var showDeleteConfirmation = false
+
+    var body: some View {
+        VStack(spacing: 12) {
+            Button {
+                Task { await toggleMonitoring() }
+            } label: {
+                Label(movie.monitored ? "Unmonitor Movie" : "Monitor Movie",
+                      systemImage: movie.monitored ? "bookmark.slash.fill" : "bookmark.fill")
+                    .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.borderedProminent)
+            .tint(movie.monitored ? .orange : .blue)
+
+            if movie.monitored && !movie.hasFile {
+                Button {
+                    Task { await triggerSearch() }
+                } label: {
+                    Label("Search for Movie", systemImage: "magnifyingglass")
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.bordered)
+            }
+
+            Button(role: .destructive) { showDeleteConfirmation = true } label: {
+                Label("Delete Movie", systemImage: "trash.fill")
+                    .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.borderedProminent)
+            .confirmationDialog("Delete \(movie.title)?",
+                                isPresented: $showDeleteConfirmation,
+                                titleVisibility: .visible) {
+                Button("Delete Movie and Files", role: .destructive) {
+                    Task { await deleteMovie(true) }
+                }
+                Button("Delete from Radarr (Keep Files)", role: .destructive) {
+                    Task { await deleteMovie(false) }
+                }
+                Button("Cancel", role: .cancel) {}
+            } message: {
+                Text("This action cannot be undone. Choose an option for file deletion.")
+            }
+        }
+    }
+}
+
+#if DEBUG
+struct ActionButtonsSection_Previews: PreviewProvider {
+    static var sampleMovie: RadarrMovie {
+        RadarrMovie(
+            id: 1,
+            title: "Sample Movie",
+            originalTitle: nil,
+            sortTitle: "Sample Movie",
+            sizeOnDisk: 5_000_000_000,
+            status: "released",
+            overview: "A sample movie overview.",
+            inCinemas: nil,
+            physicalRelease: nil,
+            digitalRelease: nil,
+            images: [],
+            website: nil,
+            year: 2023,
+            hasFile: false,
+            path: "/movies/sample",
+            qualityProfileId: 1,
+            monitored: true,
+            minimumAvailability: "released",
+            runtime: 120,
+            cleanTitle: nil,
+            imdbId: "tt1234567",
+            tmdbId: 100,
+            titleSlug: nil,
+            folderName: nil,
+            movieFile: nil
+        )
+    }
+
+    static var previews: some View {
+        ActionButtonsSection(
+            movie: sampleMovie,
+            toggleMonitoring: {},
+            triggerSearch: {},
+            deleteMovie: { _ in }
+        )
+        .padding()
+        .previewLayout(.sizeThatFits)
+    }
+}
+#endif

--- a/Cantinarr/Features/Radarr/UI/MovieDetailsSection.swift
+++ b/Cantinarr/Features/Radarr/UI/MovieDetailsSection.swift
@@ -1,0 +1,96 @@
+import SwiftUI
+
+/// Information section showing movie details like status and quality profile.
+struct MovieDetailsSection: View {
+    let movie: RadarrMovie
+    let qualityProfileName: String?
+    let formattedSizeOnDisk: String
+    let openIMDb: () -> Void
+    let openTMDb: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            DetailRow(label: "Status", value: movie.status.capitalized)
+            if let profileName = qualityProfileName {
+                DetailRow(label: "Quality Profile", value: profileName)
+            }
+            if movie.hasFile {
+                DetailRow(label: "Size on Disk", value: formattedSizeOnDisk)
+            }
+            if let path = movie.path, !path.isEmpty {
+                DetailRow(label: "Path", value: path, lineLimit: 3)
+            }
+
+            HStack {
+                if movie.imdbId != nil {
+                    Button("IMDb", action: openIMDb)
+                        .buttonStyle(.bordered)
+                }
+                if movie.tmdbId != nil {
+                    Button("TMDb", action: openTMDb)
+                        .buttonStyle(.bordered)
+                }
+            }
+            .padding(.top, 5)
+        }
+    }
+
+    private struct DetailRow: View {
+        let label: String
+        let value: String
+        var lineLimit: Int = 1
+
+        var body: some View {
+            VStack(alignment: .leading) {
+                Text(label).font(.caption).foregroundColor(.secondary)
+                Text(value).font(.callout).lineLimit(lineLimit)
+            }
+        }
+    }
+}
+
+#if DEBUG
+struct MovieDetailsSection_Previews: PreviewProvider {
+    static var sampleMovie: RadarrMovie {
+        RadarrMovie(
+            id: 1,
+            title: "Sample Movie",
+            originalTitle: nil,
+            sortTitle: "Sample Movie",
+            sizeOnDisk: 5_000_000_000,
+            status: "released",
+            overview: "A sample movie overview.",
+            inCinemas: nil,
+            physicalRelease: nil,
+            digitalRelease: nil,
+            images: [],
+            website: nil,
+            year: 2023,
+            hasFile: true,
+            path: "/movies/sample",
+            qualityProfileId: 1,
+            monitored: true,
+            minimumAvailability: "released",
+            runtime: 120,
+            cleanTitle: nil,
+            imdbId: "tt1234567",
+            tmdbId: 100,
+            titleSlug: nil,
+            folderName: nil,
+            movieFile: nil
+        )
+    }
+
+    static var previews: some View {
+        MovieDetailsSection(
+            movie: sampleMovie,
+            qualityProfileName: "1080p",
+            formattedSizeOnDisk: "5 GB",
+            openIMDb: {},
+            openTMDb: {}
+        )
+        .padding()
+        .previewLayout(.sizeThatFits)
+    }
+}
+#endif

--- a/Cantinarr/Features/Radarr/UI/MovieHeaderView.swift
+++ b/Cantinarr/Features/Radarr/UI/MovieHeaderView.swift
@@ -1,0 +1,115 @@
+import SwiftUI
+import NukeUI
+
+/// Header for the Radarr movie detail screen showing poster and basic info.
+struct MovieHeaderView: View {
+    let movie: RadarrMovie
+    let runtimeText: String
+    let availabilityText: String
+    let availabilityColor: Color
+
+    var body: some View {
+        ZStack(alignment: .bottomLeading) {
+            LinearGradient(colors: [Color.black.opacity(0.5), Color.clear],
+                           startPoint: .bottom, endPoint: .center)
+
+            HStack(alignment: .bottom, spacing: 16) {
+                LazyImage(url: movie.posterURL) { state in
+                    state.image?.resizable()
+                        .scaledToFill()
+                        .frame(width: 120, height: 180)
+                        .cornerRadius(12)
+                        .shadow(radius: 5)
+                }
+
+                VStack(alignment: .leading, spacing: 6) {
+                    Text(movie.title)
+                        .font(.title2.weight(.bold))
+                        .lineLimit(3)
+                        .foregroundColor(.white)
+
+                    HStack {
+                        Text(String(movie.year))
+                        Text("•")
+                        Text(runtimeText)
+                    }
+                    .font(.subheadline)
+                    .foregroundColor(.white.opacity(0.8))
+
+                    HStack(spacing: 6) {
+                        Circle()
+                            .fill(availabilityColor)
+                            .frame(width: 10, height: 10)
+                        Text(availabilityText)
+                            .font(.caption.weight(.medium))
+                            .foregroundColor(.white)
+                    }
+                    .padding(.vertical, 4)
+                    .padding(.horizontal, 8)
+                    .background(Color.black.opacity(0.3))
+                    .cornerRadius(6)
+                }
+                Spacer()
+            }
+            .padding()
+        }
+        .background {
+            if let url = movie.fanartURL {
+                LazyImage(url: url) { state in
+                    state.image?.resizable()
+                        .scaledToFill()
+                        .overlay(Color.black.opacity(0.3))
+                }
+            }
+        }
+        .clipped()
+    }
+}
+
+#if DEBUG
+struct MovieHeaderView_Previews: PreviewProvider {
+    static var sampleMovie: RadarrMovie {
+        RadarrMovie(
+            id: 1,
+            title: "Sample Movie",
+            originalTitle: nil,
+            sortTitle: "Sample Movie",
+            sizeOnDisk: 5_000_000_000,
+            status: "released",
+            overview: "A sample movie overview.",
+            inCinemas: nil,
+            physicalRelease: nil,
+            digitalRelease: nil,
+            images: [
+                RadarrImage(coverType: "poster", url: URL(string: "https://example.com/poster.jpg"), remoteUrl: nil),
+                RadarrImage(coverType: "fanart", url: URL(string: "https://example.com/fanart.jpg"), remoteUrl: nil)
+            ],
+            website: nil,
+            year: 2023,
+            hasFile: true,
+            path: "/movies/sample",
+            qualityProfileId: 1,
+            monitored: true,
+            minimumAvailability: "released",
+            runtime: 120,
+            cleanTitle: nil,
+            imdbId: "tt1234567",
+            tmdbId: 100,
+            titleSlug: nil,
+            folderName: nil,
+            movieFile: nil
+        )
+    }
+
+    static var previews: some View {
+        MovieHeaderView(
+            movie: sampleMovie,
+            runtimeText: "2h",
+            availabilityText: "Downloaded",
+            availabilityColor: .green
+        )
+        .previewLayout(.sizeThatFits)
+        .preferredColorScheme(.dark)
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- extract movie header, details, and action sections into dedicated views
- use the new views inside `RadarrMovieDetailView`
- add SwiftUI previews for each new component

## Testing
- `git status --short`