### PR TITLE
Refactor side menu gestures

### DIFF
--- a/Cantinarr/Features/Shell/RootShellView.swift
+++ b/Cantinarr/Features/Shell/RootShellView.swift
@@ -11,7 +11,17 @@ struct RootShellView: View {
     @State private var isMenuOpen = false
     @State private var showSettingsSheet = false
 
+    /// Width of the invisible edge used to detect swipe-from-edge gestures.
     private let edgeWidth: CGFloat = 24
+
+    /// Provides drag and tap gestures for the side menu.
+    /// The thresholds are defined in ``SideMenuGestureManager``.
+    private var menuGestures: SideMenuGestureManager {
+        SideMenuGestureManager(
+            openMenu: { withAnimation { isMenuOpen = true } },
+            closeMenu: { withAnimation { isMenuOpen = false } }
+        )
+    }
 
     var body: some View {
         ZStack(alignment: .leading) {
@@ -36,43 +46,20 @@ struct RootShellView: View {
                 if isMenuOpen {
                     Color.clear
                         .contentShape(Rectangle())
-                        .onTapGesture {
-                            withAnimation { isMenuOpen = false }
-                        }
-                        .gesture(
-                            DragGesture(minimumDistance: 20)
-                                .onEnded { value in
-                                    if value.translation.width < -40 {
-                                        withAnimation { isMenuOpen = false }
-                                    }
-                                }
-                        )
+                        .onTapGesture { menuGestures.closeMenu() }
+                        .gesture(menuGestures.closeDragGesture())
                         .ignoresSafeArea()
                 }
             }
             // Gesture to close menu by swiping left on content area
-            .gesture(
-                DragGesture(minimumDistance: 20)
-                    .onEnded { value in
-                        if isMenuOpen, value.translation.width < -40 {
-                            withAnimation { isMenuOpen = false }
-                        }
-                    }
-            )
+            .gesture(menuGestures.closeDragGesture())
             // Overlay for edge swipe to open menu
             .overlay(alignment: .leading) {
                 if !isMenuOpen {
                     Color.clear
                         .frame(width: edgeWidth)
                         .contentShape(Rectangle())
-                        .gesture(
-                            DragGesture(minimumDistance: 20)
-                                .onEnded { value in
-                                    if value.translation.width > 40 {
-                                        withAnimation { isMenuOpen = true }
-                                    }
-                                }
-                        )
+                        .gesture(menuGestures.openDragGesture())
                         .ignoresSafeArea(.container, edges: [.vertical])
                 }
             }

--- a/Cantinarr/Features/Shell/SideMenuGestureManager.swift
+++ b/Cantinarr/Features/Shell/SideMenuGestureManager.swift
@@ -1,0 +1,45 @@
+// File: SideMenuGestureManager.swift
+// Purpose: Encapsulates drag and tap gestures for the side menu
+
+import SwiftUI
+
+/// Handles the gestures that control the slide-out side menu.
+/// The `dragThreshold` determines how far the user must drag before the
+/// menu opens or closes. Use this helper in `RootShellView` to keep gesture
+/// logic separate from view layout code.
+struct SideMenuGestureManager {
+    /// Called when a drag or tap should open the menu.
+    var openMenu: () -> Void
+    /// Called when a drag or tap should close the menu.
+    var closeMenu: () -> Void
+
+    /// Minimum drag movement before a drag is considered.
+    var minDragDistance: CGFloat = 20
+    /// Points the user must drag horizontally before the menu toggles.
+    var dragThreshold: CGFloat = 40
+
+    /// Dragging right past `dragThreshold` opens the menu.
+    func openDragGesture() -> some Gesture {
+        DragGesture(minimumDistance: minDragDistance)
+            .onEnded { value in
+                if value.translation.width > dragThreshold {
+                    openMenu()
+                }
+            }
+    }
+
+    /// Dragging left past `dragThreshold` closes the menu.
+    func closeDragGesture() -> some Gesture {
+        DragGesture(minimumDistance: minDragDistance)
+            .onEnded { value in
+                if value.translation.width < -dragThreshold {
+                    closeMenu()
+                }
+            }
+    }
+
+    /// Tap gesture used to dismiss the menu overlay.
+    func closeTapGesture() -> some Gesture {
+        TapGesture().onEnded { closeMenu() }
+    }
+}


### PR DESCRIPTION
## Summary
- introduce `SideMenuGestureManager` to centralise drag and tap logic
- use `SideMenuGestureManager` in `RootShellView`
- document gesture thresholds

## Testing
- `swiftc -typecheck Cantinarr/Features/Shell/SideMenuGestureManager.swift Cantinarr/Features/Shell/RootShellView.swift` *(fails: no such module 'SwiftUI')*