### PR TITLE
Add shared generic UI components

### DIFF
--- a/Cantinarr/Features/OverseerrUsers/UI/OverseerrUsersAdvancedView.swift
+++ b/Cantinarr/Features/OverseerrUsers/UI/OverseerrUsersAdvancedView.swift
@@ -231,8 +231,13 @@ private struct SearchResultsSection: View {
 
                 VStack(alignment: .leading, spacing: 8) {
                     if (isSearchLoadingLocal || isLoadingSearch) && results.isEmpty {
-                        HorizontalMediaRow(items: [], isLoading: true) { _ in }
-                            .frame(height: 180)
+                        HorizontalItemRow(items: [MediaItem](), isLoading: true, onAppear: { _ in }) {
+                            MediaCardView(id: 0, mediaType: .movie, title: "", posterPath: nil)
+                                .frame(width: 110)
+                        } placeholder: {
+                            LoadingCardView()
+                        }
+                        .frame(height: 180)
                     } else if !isSearchLoadingLocal && !isLoadingSearch && results.isEmpty {
                         HStack {
                             Spacer()
@@ -247,11 +252,18 @@ private struct SearchResultsSection: View {
                         }
                         .frame(height: 160)
                     } else {
-                        HorizontalMediaRow(
+                        HorizontalItemRow(
                             items: results,
-                            isLoading: isLoadingSearch
+                            isLoading: isLoadingSearch,
+                            onAppear: { item in loadMore(item) }
                         ) { item in
-                            loadMore(item)
+                            MediaCardView(id: item.id,
+                                          mediaType: item.mediaType,
+                                          title: item.title,
+                                          posterPath: item.posterPath)
+                                .frame(width: 110)
+                        } placeholder: {
+                            LoadingCardView()
                         }
                     }
                 }
@@ -310,22 +322,36 @@ private struct RecommendationRowsView: View {
                 Text("Movies you might like")
                     .font(.headline)
                     .padding(.horizontal)
-                HorizontalMediaRow(
+                HorizontalItemRow(
                     items: movieRecs,
-                    isLoading: isLoadingMovie
+                    isLoading: isLoadingMovie,
+                    onAppear: { item in loadMoreMovie(item) }
                 ) { item in
-                    loadMoreMovie(item)
+                    MediaCardView(id: item.id,
+                                  mediaType: item.mediaType,
+                                  title: item.title,
+                                  posterPath: item.posterPath)
+                        .frame(width: 110)
+                } placeholder: {
+                    LoadingCardView()
                 }
             }
             if !tvRecs.isEmpty {
                 Text("Shows you might like")
                     .font(.headline)
                     .padding(.horizontal)
-                HorizontalMediaRow(
+                HorizontalItemRow(
                     items: tvRecs,
-                    isLoading: isLoadingTv
+                    isLoading: isLoadingTv,
+                    onAppear: { item in loadMoreTv(item) }
                 ) { item in
-                    loadMoreTv(item)
+                    MediaCardView(id: item.id,
+                                  mediaType: item.mediaType,
+                                  title: item.title,
+                                  posterPath: item.posterPath)
+                        .frame(width: 110)
+                } placeholder: {
+                    LoadingCardView()
                 }
             }
         }

--- a/Cantinarr/Features/OverseerrUsers/UI/OverseerrUsersAdvancedView.swift
+++ b/Cantinarr/Features/OverseerrUsers/UI/OverseerrUsersAdvancedView.swift
@@ -231,7 +231,7 @@ private struct SearchResultsSection: View {
 
                 VStack(alignment: .leading, spacing: 8) {
                     if (isSearchLoadingLocal || isLoadingSearch) && results.isEmpty {
-                        HorizontalItemRow(items: [MediaItem](), isLoading: true, onAppear: { _ in }) {
+                        HorizontalItemRow(items: [MediaItem](), isLoading: true, onAppear: { _ in }) { _ in
                             MediaCardView(id: 0, mediaType: .movie, title: "", posterPath: nil)
                                 .frame(width: 110)
                         } placeholder: {

--- a/Cantinarr/Features/OverseerrUsers/UI/OverseerrUsersExtras.swift
+++ b/Cantinarr/Features/OverseerrUsers/UI/OverseerrUsersExtras.swift
@@ -64,4 +64,3 @@ struct ActiveKeywordsView: View {
         }
     }
 }
-

--- a/Cantinarr/Features/OverseerrUsers/UI/OverseerrUsersExtras.swift
+++ b/Cantinarr/Features/OverseerrUsers/UI/OverseerrUsersExtras.swift
@@ -3,67 +3,16 @@
 
 import SwiftUI
 
-// MARK: – Horizontal scroll row
-
-struct HorizontalMediaRow: View {
-    let items: [OverseerrUsersViewModel.MediaItem]
-    let isLoading: Bool
-    let onAppear: (OverseerrUsersViewModel.MediaItem) -> Void
-
-    var body: some View {
-        ScrollView(.horizontal, showsIndicators: false) {
-            LazyHStack(spacing: 12) {
-                if items.isEmpty && isLoading {
-                    // show 5 shimmering placeholders
-                    ForEach(0 ..< 5, id: \.self) { _ in
-                        LoadingMediaCardView()
-                    }
-                } else {
-                    ForEach(items) { item in
-                        MediaCardView(id: item.id,
-                                      mediaType: item.mediaType,
-                                      title: item.title,
-                                      posterPath: item.posterPath)
-                            .frame(width: 110)
-                            .onAppear { onAppear(item) } // Call the closure with the item
-                    }
-                    // at the end, if still loading more, show one more placeholder
-                    if isLoading && !items.isEmpty { // Only show trailing loader if there are items
-                        LoadingMediaCardView()
-                    }
-                }
-            }
-            .padding(.horizontal)
-        }
-        // It's good for HorizontalMediaRow to have a defined height if its content can vary
-        // or if it's used in contexts where an intrinsic height isn't easily determined.
-        // For example, if MediaCardView has a fixed height of ~180 (150 for image + text + spacing).
-        .frame(height: 200) // Example height, adjust based on MediaCardView's content
-    }
-}
+/// Convenience typealias used in this feature
+typealias MediaItem = OverseerrUsersViewModel.MediaItem
 
 // MARK: – Keyword suggestion pills
-
-struct KeywordPill: View {
-    let keyword: OverseerrAPIService
-        .Keyword // Ensure OverseerrAPIService.Keyword is Identifiable if used in ForEach directly
-
-    var body: some View {
-        Text(keyword.name)
-            .font(.caption) // Slightly smaller for pills
-            .padding(.vertical, 8) // Adjusted padding
-            .padding(.horizontal, 14) // Adjusted padding
-            .background(Capsule().fill(Color.accentColor.opacity(0.15))) // Slightly adjust opacity
-            .foregroundColor(.accentColor) // Make text accent color for better theme fit
-            .lineLimit(1)
-    }
-}
 
 struct KeywordSuggestionRow: View {
     let keywords: [OverseerrAPIService.Keyword] // Ensure OverseerrAPIService.Keyword is Identifiable
     let choose: (OverseerrAPIService.Keyword) -> Void
 
-    // Adjust rows based on desired density and KeywordPill height
+    // Adjust rows based on desired density and pill height
     private let rows: [GridItem] = [
         GridItem(.flexible(minimum: 32, maximum: 40)), // Allow some flexibility
         GridItem(.flexible(minimum: 32, maximum: 40)),
@@ -74,7 +23,7 @@ struct KeywordSuggestionRow: View {
             // Using LazyHGrid for potentially many keywords
             LazyHGrid(rows: rows, spacing: 8) {
                 ForEach(keywords) { kw in // Keyword must be Identifiable
-                    KeywordPill(keyword: kw)
+                    PillView(item: kw, nameKeyPath: \.name)
                         .onTapGesture { choose(kw) }
                 }
             }
@@ -116,20 +65,3 @@ struct ActiveKeywordsView: View {
     }
 }
 
-struct LoadingMediaCardView: View {
-    var body: some View {
-        VStack(spacing: 8) {
-            RoundedRectangle(cornerRadius: 8)
-                .fill(Color.secondary.opacity(0.1)) // Use secondary for placeholder bg
-                .frame(height: 150)
-                .shimmer()
-
-            RoundedRectangle(cornerRadius: 4)
-                .fill(Color.secondary.opacity(0.1))
-                .frame(height: 12)
-                .padding(.horizontal, 16)
-                .shimmer()
-        }
-        .frame(width: 110)
-    }
-}

--- a/Cantinarr/Features/OverseerrUsers/UI/OverseerrUsersHomeView.swift
+++ b/Cantinarr/Features/OverseerrUsers/UI/OverseerrUsersHomeView.swift
@@ -214,7 +214,7 @@ struct OverseerrUsersHomeView: View {
             // Movie Recommendations
             if overseerrUsersVM.isLoadingMovieRecs && overseerrUsersVM.movieRecs.isEmpty {
                 Text("Movies You Might Like").font(.headline).padding(.horizontal).opacity(0) // Placeholder title
-                HorizontalItemRow(items: [MediaItem](), isLoading: true, onAppear: { _ in }) {
+                HorizontalItemRow(items: [MediaItem](), isLoading: true, onAppear: { _ in }) { _ in
                     MediaCardView(id: 0, mediaType: .movie, title: "", posterPath: nil)
                         .frame(width: 110)
                 } placeholder: {
@@ -242,7 +242,7 @@ struct OverseerrUsersHomeView: View {
             // TV Recommendations
             if overseerrUsersVM.isLoadingTvRecs && overseerrUsersVM.tvRecs.isEmpty {
                 Text("Shows You Might Like").font(.headline).padding(.horizontal).opacity(0) // Placeholder title
-                HorizontalItemRow(items: [MediaItem](), isLoading: true, onAppear: { _ in }) {
+                HorizontalItemRow(items: [MediaItem](), isLoading: true, onAppear: { _ in }) { _ in
                     MediaCardView(id: 0, mediaType: .movie, title: "", posterPath: nil)
                         .frame(width: 110)
                 } placeholder: {
@@ -304,7 +304,7 @@ private struct TrendingDisplayView: View {
                 .font(.title2)
                 .padding(.horizontal)
                 .opacity(0)
-            HorizontalItemRow(items: [MediaItem](), isLoading: true, onAppear: { _ in }) {
+            HorizontalItemRow(items: [MediaItem](), isLoading: true, onAppear: { _ in }) { _ in
                 MediaCardView(id: 0, mediaType: .movie, title: "", posterPath: nil)
                     .frame(width: 110)
             } placeholder: {
@@ -351,7 +351,7 @@ private struct SearchResultsRowView: View {
                 .font(.headline)
                 .padding(.horizontal)
                 .opacity(0)
-            HorizontalItemRow(items: [MediaItem](), isLoading: true, onAppear: { _ in }) {
+            HorizontalItemRow(items: [MediaItem](), isLoading: true, onAppear: { _ in }) { _ in
                 MediaCardView(id: 0, mediaType: .movie, title: "", posterPath: nil)
                     .frame(width: 110)
             } placeholder: {

--- a/Cantinarr/Features/OverseerrUsers/UI/OverseerrUsersHomeView.swift
+++ b/Cantinarr/Features/OverseerrUsers/UI/OverseerrUsersHomeView.swift
@@ -214,32 +214,56 @@ struct OverseerrUsersHomeView: View {
             // Movie Recommendations
             if overseerrUsersVM.isLoadingMovieRecs && overseerrUsersVM.movieRecs.isEmpty {
                 Text("Movies You Might Like").font(.headline).padding(.horizontal).opacity(0) // Placeholder title
-                HorizontalMediaRow(items: [], isLoading: true) { _ in }
-                    .frame(height: 200)
+                HorizontalItemRow(items: [MediaItem](), isLoading: true, onAppear: { _ in }) {
+                    MediaCardView(id: 0, mediaType: .movie, title: "", posterPath: nil)
+                        .frame(width: 110)
+                } placeholder: {
+                    LoadingCardView()
+                }
+                .frame(height: 200)
             } else if !overseerrUsersVM.movieRecs.isEmpty {
                 Text("Movies You Might Like")
                     .font(.headline).padding(.horizontal)
-                HorizontalMediaRow(
+                HorizontalItemRow(
                     items: overseerrUsersVM.movieRecs,
-                    isLoading: overseerrUsersVM.isLoadingMovieRecs
+                    isLoading: overseerrUsersVM.isLoadingMovieRecs,
+                    onAppear: { item in overseerrUsersVM.loadMoreMovieRecsIfNeeded(current: item) }
                 ) { item in
-                    overseerrUsersVM.loadMoreMovieRecsIfNeeded(current: item)
+                    MediaCardView(id: item.id,
+                                  mediaType: item.mediaType,
+                                  title: item.title,
+                                  posterPath: item.posterPath)
+                        .frame(width: 110)
+                } placeholder: {
+                    LoadingCardView()
                 }
             }
 
             // TV Recommendations
             if overseerrUsersVM.isLoadingTvRecs && overseerrUsersVM.tvRecs.isEmpty {
                 Text("Shows You Might Like").font(.headline).padding(.horizontal).opacity(0) // Placeholder title
-                HorizontalMediaRow(items: [], isLoading: true) { _ in }
-                    .frame(height: 200)
+                HorizontalItemRow(items: [MediaItem](), isLoading: true, onAppear: { _ in }) {
+                    MediaCardView(id: 0, mediaType: .movie, title: "", posterPath: nil)
+                        .frame(width: 110)
+                } placeholder: {
+                    LoadingCardView()
+                }
+                .frame(height: 200)
             } else if !overseerrUsersVM.tvRecs.isEmpty {
                 Text("Shows You Might Like")
                     .font(.headline).padding(.horizontal)
-                HorizontalMediaRow(
+                HorizontalItemRow(
                     items: overseerrUsersVM.tvRecs,
-                    isLoading: overseerrUsersVM.isLoadingTvRecs
+                    isLoading: overseerrUsersVM.isLoadingTvRecs,
+                    onAppear: { item in overseerrUsersVM.loadMoreTvRecsIfNeeded(current: item) }
                 ) { item in
-                    overseerrUsersVM.loadMoreTvRecsIfNeeded(current: item)
+                    MediaCardView(id: item.id,
+                                  mediaType: item.mediaType,
+                                  title: item.title,
+                                  posterPath: item.posterPath)
+                        .frame(width: 110)
+                } placeholder: {
+                    LoadingCardView()
                 }
             }
         }
@@ -280,14 +304,27 @@ private struct TrendingDisplayView: View {
                 .font(.title2)
                 .padding(.horizontal)
                 .opacity(0)
-            HorizontalMediaRow(items: [], isLoading: true) { _ in }
-                .frame(height: 200)
+            HorizontalItemRow(items: [MediaItem](), isLoading: true, onAppear: { _ in }) {
+                MediaCardView(id: 0, mediaType: .movie, title: "", posterPath: nil)
+                    .frame(width: 110)
+            } placeholder: {
+                LoadingCardView()
+            }
+            .frame(height: 200)
         } else if !items.isEmpty {
             Text("Trending")
                 .font(.title2)
                 .padding(.horizontal)
-            HorizontalMediaRow(items: items, isLoading: isLoading) { item in
+            HorizontalItemRow(items: items, isLoading: isLoading, onAppear: { item in
                 loadMore(item)
+            }) { item in
+                MediaCardView(id: item.id,
+                              mediaType: item.mediaType,
+                              title: item.title,
+                              posterPath: item.posterPath)
+                    .frame(width: 110)
+            } placeholder: {
+                LoadingCardView()
             }
         } else {
             Text("Trending")
@@ -314,8 +351,13 @@ private struct SearchResultsRowView: View {
                 .font(.headline)
                 .padding(.horizontal)
                 .opacity(0)
-            HorizontalMediaRow(items: [], isLoading: true) { _ in }
-                .frame(height: 200)
+            HorizontalItemRow(items: [MediaItem](), isLoading: true, onAppear: { _ in }) {
+                MediaCardView(id: 0, mediaType: .movie, title: "", posterPath: nil)
+                    .frame(width: 110)
+            } placeholder: {
+                LoadingCardView()
+            }
+            .frame(height: 200)
         } else if !showLocalLoading && !isLoading && results.isEmpty && !searchText.isEmpty {
             HStack {
                 Spacer()
@@ -335,8 +377,16 @@ private struct SearchResultsRowView: View {
             Text("Search Results")
                 .font(.headline)
                 .padding(.horizontal)
-            HorizontalMediaRow(items: results, isLoading: isLoading) { item in
+            HorizontalItemRow(items: results, isLoading: isLoading, onAppear: { item in
                 loadMore(item)
+            }) { item in
+                MediaCardView(id: item.id,
+                              mediaType: item.mediaType,
+                              title: item.title,
+                              posterPath: item.posterPath)
+                    .frame(width: 110)
+            } placeholder: {
+                LoadingCardView()
             }
         }
     }

--- a/Cantinarr/Features/Shared/UI/HorizontalItemRow.swift
+++ b/Cantinarr/Features/Shared/UI/HorizontalItemRow.swift
@@ -12,7 +12,8 @@ struct HorizontalItemRow<Item: Identifiable, ItemView: View, PlaceholderView: Vi
          isLoading: Bool,
          onAppear: @escaping (Item) -> Void,
          @ViewBuilder content: @escaping (Item) -> ItemView,
-         @ViewBuilder placeholder: @escaping () -> PlaceholderView) {
+         @ViewBuilder placeholder: @escaping () -> PlaceholderView)
+    {
         self.items = items
         self.isLoading = isLoading
         self.onAppear = onAppear
@@ -25,7 +26,8 @@ extension HorizontalItemRow where PlaceholderView == EmptyView {
     init(items: [Item],
          isLoading: Bool,
          onAppear: @escaping (Item) -> Void,
-         @ViewBuilder content: @escaping (Item) -> ItemView) {
+         @ViewBuilder content: @escaping (Item) -> ItemView)
+    {
         self.init(items: items,
                   isLoading: isLoading,
                   onAppear: onAppear,
@@ -58,22 +60,26 @@ extension HorizontalItemRow {
 }
 
 #if DEBUG
-private struct HorizontalItemRow_Previews: PreviewProvider {
-    struct ExampleItem: Identifiable { let id: Int; let title: String }
-    static var previews: some View {
-        HorizontalItemRow(items: [ExampleItem(id: 1, title: "One"), ExampleItem(id: 2, title: "Two")], isLoading: true, onAppear: { _ in }) { item in
-            Text(item.title)
-                .frame(width: 100, height: 80)
-                .background(Color.blue.opacity(0.2))
-                .cornerRadius(8)
-        } placeholder: {
-            RoundedRectangle(cornerRadius: 8)
-                .fill(Color.gray.opacity(0.3))
-                .frame(width: 100, height: 80)
-                .shimmer()
+    private struct HorizontalItemRow_Previews: PreviewProvider {
+        struct ExampleItem: Identifiable { let id: Int; let title: String }
+        static var previews: some View {
+            HorizontalItemRow(
+                items: [ExampleItem(id: 1, title: "One"), ExampleItem(id: 2, title: "Two")],
+                isLoading: true,
+                onAppear: { _ in }
+            ) { item in
+                Text(item.title)
+                    .frame(width: 100, height: 80)
+                    .background(Color.blue.opacity(0.2))
+                    .cornerRadius(8)
+            } placeholder: {
+                RoundedRectangle(cornerRadius: 8)
+                    .fill(Color.gray.opacity(0.3))
+                    .frame(width: 100, height: 80)
+                    .shimmer()
+            }
+            .frame(height: 100)
+            .previewLayout(.sizeThatFits)
         }
-        .frame(height: 100)
-        .previewLayout(.sizeThatFits)
     }
-}
 #endif

--- a/Cantinarr/Features/Shared/UI/HorizontalItemRow.swift
+++ b/Cantinarr/Features/Shared/UI/HorizontalItemRow.swift
@@ -1,0 +1,79 @@
+import SwiftUI
+
+/// A generic horizontally scrolling row that can show loading placeholders.
+struct HorizontalItemRow<Item: Identifiable, ItemView: View, PlaceholderView: View>: View {
+    let items: [Item]
+    let isLoading: Bool
+    let onAppear: (Item) -> Void
+    let content: (Item) -> ItemView
+    let placeholder: () -> PlaceholderView
+
+    init(items: [Item],
+         isLoading: Bool,
+         onAppear: @escaping (Item) -> Void,
+         @ViewBuilder content: @escaping (Item) -> ItemView,
+         @ViewBuilder placeholder: @escaping () -> PlaceholderView) {
+        self.items = items
+        self.isLoading = isLoading
+        self.onAppear = onAppear
+        self.content = content
+        self.placeholder = placeholder
+    }
+}
+
+extension HorizontalItemRow where PlaceholderView == EmptyView {
+    init(items: [Item],
+         isLoading: Bool,
+         onAppear: @escaping (Item) -> Void,
+         @ViewBuilder content: @escaping (Item) -> ItemView) {
+        self.init(items: items,
+                  isLoading: isLoading,
+                  onAppear: onAppear,
+                  content: content,
+                  placeholder: { EmptyView() })
+    }
+}
+
+extension HorizontalItemRow {
+    var body: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            LazyHStack(spacing: 12) {
+                if items.isEmpty && isLoading {
+                    ForEach(0 ..< 5, id: \.self) { _ in
+                        placeholder()
+                    }
+                } else {
+                    ForEach(items) { item in
+                        content(item)
+                            .onAppear { onAppear(item) }
+                    }
+                    if isLoading && !items.isEmpty {
+                        placeholder()
+                    }
+                }
+            }
+            .padding(.horizontal)
+        }
+    }
+}
+
+#if DEBUG
+private struct HorizontalItemRow_Previews: PreviewProvider {
+    struct ExampleItem: Identifiable { let id: Int; let title: String }
+    static var previews: some View {
+        HorizontalItemRow(items: [ExampleItem(id: 1, title: "One"), ExampleItem(id: 2, title: "Two")], isLoading: true, onAppear: { _ in }) { item in
+            Text(item.title)
+                .frame(width: 100, height: 80)
+                .background(Color.blue.opacity(0.2))
+                .cornerRadius(8)
+        } placeholder: {
+            RoundedRectangle(cornerRadius: 8)
+                .fill(Color.gray.opacity(0.3))
+                .frame(width: 100, height: 80)
+                .shimmer()
+        }
+        .frame(height: 100)
+        .previewLayout(.sizeThatFits)
+    }
+}
+#endif

--- a/Cantinarr/Features/Shared/UI/LoadingCardView.swift
+++ b/Cantinarr/Features/Shared/UI/LoadingCardView.swift
@@ -1,0 +1,39 @@
+import SwiftUI
+
+/// Simple skeleton card used while loading content.
+struct LoadingCardView: View {
+    let width: CGFloat
+    let imageHeight: CGFloat
+    let lineHeight: CGFloat
+
+    init(width: CGFloat = 110, imageHeight: CGFloat = 150, lineHeight: CGFloat = 12) {
+        self.width = width
+        self.imageHeight = imageHeight
+        self.lineHeight = lineHeight
+    }
+
+    var body: some View {
+        VStack(spacing: 8) {
+            RoundedRectangle(cornerRadius: 8)
+                .fill(Color.secondary.opacity(0.1))
+                .frame(height: imageHeight)
+                .shimmer()
+
+            RoundedRectangle(cornerRadius: 4)
+                .fill(Color.secondary.opacity(0.1))
+                .frame(height: lineHeight)
+                .padding(.horizontal, 16)
+                .shimmer()
+        }
+        .frame(width: width)
+    }
+}
+
+#if DEBUG
+private struct LoadingCardView_Previews: PreviewProvider {
+    static var previews: some View {
+        LoadingCardView()
+            .previewLayout(.sizeThatFits)
+    }
+}
+#endif

--- a/Cantinarr/Features/Shared/UI/LoadingCardView.swift
+++ b/Cantinarr/Features/Shared/UI/LoadingCardView.swift
@@ -30,10 +30,10 @@ struct LoadingCardView: View {
 }
 
 #if DEBUG
-private struct LoadingCardView_Previews: PreviewProvider {
-    static var previews: some View {
-        LoadingCardView()
-            .previewLayout(.sizeThatFits)
+    private struct LoadingCardView_Previews: PreviewProvider {
+        static var previews: some View {
+            LoadingCardView()
+                .previewLayout(.sizeThatFits)
+        }
     }
-}
 #endif

--- a/Cantinarr/Features/Shared/UI/PillView.swift
+++ b/Cantinarr/Features/Shared/UI/PillView.swift
@@ -1,0 +1,37 @@
+import SwiftUI
+
+/// Simple capsule shaped pill displaying the provided item's name using a key path.
+struct PillView<Item>: View {
+    let item: Item
+    let nameKeyPath: KeyPath<Item, String>
+
+    init(item: Item, nameKeyPath: KeyPath<Item, String>) {
+        self.item = item
+        self.nameKeyPath = nameKeyPath
+    }
+
+    var body: some View {
+        Text(item[keyPath: nameKeyPath])
+            .font(.caption)
+            .padding(.vertical, 8)
+            .padding(.horizontal, 14)
+            .background(Capsule().fill(Color.accentColor.opacity(0.15)))
+            .foregroundColor(.accentColor)
+            .lineLimit(1)
+    }
+}
+
+extension PillView where Item == String {
+    init(text: String) {
+        self.init(item: text, nameKeyPath: \.self)
+    }
+}
+
+#if DEBUG
+private struct PillView_Previews: PreviewProvider {
+    static var previews: some View {
+        PillView(text: "Example")
+            .previewLayout(.sizeThatFits)
+    }
+}
+#endif

--- a/Cantinarr/Features/Shared/UI/PillView.swift
+++ b/Cantinarr/Features/Shared/UI/PillView.swift
@@ -28,10 +28,10 @@ extension PillView where Item == String {
 }
 
 #if DEBUG
-private struct PillView_Previews: PreviewProvider {
-    static var previews: some View {
-        PillView(text: "Example")
-            .previewLayout(.sizeThatFits)
+    private struct PillView_Previews: PreviewProvider {
+        static var previews: some View {
+            PillView(text: "Example")
+                .previewLayout(.sizeThatFits)
+        }
     }
-}
 #endif


### PR DESCRIPTION
## Summary
- create a generic `HorizontalItemRow` for horizontally scrolling lists
- add reusable `PillView` and `LoadingCardView`
- adapt Overseerr views to use the new shared components
- remove old implementations from `OverseerrUsersExtras`
- add SwiftUI previews for the shared views
- fix type inference issues for empty arrays

## Testing
- `swift --version`
