### PR TITLE
Fix environment lookup to avoid crash

### DIFF
--- a/Cantinarr/Core/Stores/EnvironmentsStore.swift
+++ b/Cantinarr/Core/Stores/EnvironmentsStore.swift
@@ -86,7 +86,10 @@ final class EnvironmentsStore: ObservableObject {
     // MARK:  – Convenience
 
     var selectedEnvironment: ServerEnvironment {
-        environments.first { $0.id == selectedEnvironmentID }!
+        guard let env = environments.first(where: { $0.id == selectedEnvironmentID }) else {
+            fatalError("selectedEnvironmentID not found in environments")
+        }
+        return env
     }
 
     var selectedServiceInstance: ServiceInstance? {


### PR DESCRIPTION
## Summary
- guard selected environment lookup rather than force unwrapping

## Testing
- `swift --version`