### PR TITLE
Refactor Radarr history models

### DIFF
--- a/Cantinarr/Features/Radarr/Models/RadarrHistoryData.swift
+++ b/Cantinarr/Features/Radarr/Models/RadarrHistoryData.swift
@@ -1,0 +1,25 @@
+// File: RadarrHistoryData.swift
+// Purpose: Defines RadarrHistoryData component for Cantinarr
+
+import Foundation
+
+struct RadarrHistoryData: Codable {
+    let nzbInfoUrl: String? // Note: Radarr's casing might vary
+    let releaseGroup: String?
+    let age: String? // Radarr often returns age as a string like "1d" or "1h"
+    // ... other fields that might appear in the 'data' dictionary
+    let message: String?
+    let reason: String? // For failed events
+    let downloadClient: String?
+    let downloadClientName: String?
+
+    enum CodingKeys: String, CodingKey {
+        case nzbInfoUrl
+        case releaseGroup
+        case age
+        case message
+        case reason
+        case downloadClient
+        case downloadClientName
+    }
+}

--- a/Cantinarr/Features/Radarr/Models/RadarrHistoryQuality.swift
+++ b/Cantinarr/Features/Radarr/Models/RadarrHistoryQuality.swift
@@ -1,0 +1,9 @@
+// File: RadarrHistoryQuality.swift
+// Purpose: Defines RadarrHistoryQuality component for Cantinarr
+
+import Foundation
+
+struct RadarrHistoryQuality: Codable {
+    let quality: RadarrQualityDetail?
+    let revision: RadarrRevision?
+}

--- a/Cantinarr/Features/Radarr/Models/RadarrMovieHistoryRecord.swift
+++ b/Cantinarr/Features/Radarr/Models/RadarrMovieHistoryRecord.swift
@@ -1,0 +1,15 @@
+// File: RadarrMovieHistoryRecord.swift
+// Purpose: Defines RadarrMovieHistoryRecord component for Cantinarr
+
+import Foundation
+
+struct RadarrMovieHistoryRecord: Codable, Identifiable {
+    let id: Int
+    let movieId: Int
+    let sourceTitle: String?
+    let quality: RadarrHistoryQuality?
+    let qualityCutoffNotMet: Bool?
+    let date: Date?
+    let eventType: String? // e.g. "grabbed", "downloadFolderImported", "downloadFailed"
+    let data: RadarrHistoryData?
+}

--- a/Cantinarr/Features/Radarr/Models/RadarrQualityDetail.swift
+++ b/Cantinarr/Features/Radarr/Models/RadarrQualityDetail.swift
@@ -1,0 +1,11 @@
+// File: RadarrQualityDetail.swift
+// Purpose: Defines RadarrQualityDetail component for Cantinarr
+
+import Foundation
+
+struct RadarrQualityDetail: Codable {
+    let id: Int?
+    let name: String?
+    let source: String?
+    let resolution: Int?
+}

--- a/Cantinarr/Features/Radarr/Models/RadarrRevision.swift
+++ b/Cantinarr/Features/Radarr/Models/RadarrRevision.swift
@@ -1,0 +1,10 @@
+// File: RadarrRevision.swift
+// Purpose: Defines RadarrRevision component for Cantinarr
+
+import Foundation
+
+struct RadarrRevision: Codable {
+    let version: Int?
+    let real: Int?
+    let isRepack: Bool?
+}

--- a/Cantinarr/Features/Radarr/RadarrAPIService.swift
+++ b/Cantinarr/Features/Radarr/RadarrAPIService.swift
@@ -328,57 +328,6 @@ class RadarrAPIService: ObservableObject { // ADDED ObservableObject conformance
         return "\(alphanumericTitle)-\(year)".replacingOccurrences(of: "--+", with: "-", options: .regularExpression)
     }
 
-    // Renamed to avoid conflict if you add a model named MovieHistoryRecord
-    struct RadarrMovieHistoryRecord: Codable, Identifiable { // Corrected struct name
-        let id: Int
-        let movieId: Int
-        let sourceTitle: String?
-        let quality: RadarrHistoryQuality?
-        let qualityCutoffNotMet: Bool?
-        let date: Date?
-        let eventType: String? // e.g. "grabbed", "downloadFolderImported", "downloadFailed"
-        let data: RadarrHistoryData?
-    }
-
-    struct RadarrHistoryQuality: Codable {
-        let quality: RadarrQualityDetail?
-        let revision: RadarrRevision?
-    }
-
-    struct RadarrQualityDetail: Codable {
-        let id: Int?
-        let name: String?
-        let source: String?
-        let resolution: Int?
-    }
-
-    struct RadarrRevision: Codable {
-        let version: Int?
-        let real: Int?
-        let isRepack: Bool?
-    }
-
-    struct RadarrHistoryData: Codable {
-        let nzbInfoUrl: String? // Note: Radarr's casing might vary
-        let releaseGroup: String?
-        let age: String? // Radarr often returns age as a string like "1d" or "1h"
-        // ... other fields that might appear in the 'data' dictionary
-        let message: String?
-        let reason: String? // For failed events
-        let downloadClient: String?
-        let downloadClientName: String?
-
-        // Custom coding keys if JSON keys are different (e.g., "NzbInfoUrl" vs "nzbInfoUrl")
-        enum CodingKeys: String, CodingKey {
-            case nzbInfoUrl
-            case releaseGroup
-            case age
-            case message
-            case reason
-            case downloadClient
-            case downloadClientName
-        }
-    }
 }
 
 extension RadarrAPIService: RadarrServiceType {}


### PR DESCRIPTION
## Summary
- add standalone Radarr history model files
- reference moved models from RadarrAPIService

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683a008f5b788333bc7f42632488280f