### PR TITLE
Add EnvironmentsStore persistence tests

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -19,6 +19,7 @@ let package = Package(
             ],
             sources: [
                 "Core/Models",
+                "Core/Stores",
                 "Features/Radarr/Models",
                 "Features/OverseerrUsers/Models"
             ]

--- a/Tests/EnvironmentsStoreTests.swift
+++ b/Tests/EnvironmentsStoreTests.swift
@@ -1,0 +1,41 @@
+import XCTest
+@testable import CantinarrModels
+
+#if canImport(Combine) && canImport(SwiftUI)
+final class EnvironmentsStoreTests: XCTestCase {
+    func testLoadSaveAndValidateSelections() throws {
+        // Use a unique temporary directory for isolation
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        let fileURL = tempDir.appendingPathComponent("env.json")
+
+        // Initial store writes data to disk
+        let store = EnvironmentsStore(fileURL: fileURL)
+        var env = ServerEnvironment(name: "Demo")
+        let svc = ServiceInstance(kind: .overseerrUsers, displayName: "Demo Service")
+        env.services = [svc]
+        store.environments = [env]
+        store.selectedEnvironmentID = env.id
+        store.selectedServiceID = svc.id
+        try store.saveNow()
+
+        // Loading a new instance should restore the environments
+        let loaded = EnvironmentsStore(fileURL: fileURL)
+        XCTAssertEqual(loaded.environments.count, 1)
+        XCTAssertEqual(loaded.environments.first?.name, "Demo")
+
+        // ValidateSelections adjusts service when removed
+        loaded.selectedEnvironmentID = loaded.environments.first!.id
+        loaded.selectedServiceID = loaded.environments.first!.services.first!.id
+        loaded.environments[0].services.removeAll()
+        loaded.validateSelections()
+        XCTAssertNil(loaded.selectedServiceID)
+
+        // Removing all environments clears selection
+        loaded.environments.removeAll()
+        loaded.validateSelections()
+        XCTAssertNil(loaded.selectedServiceID)
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- expose a `saveNow` helper and allow custom save location in `EnvironmentsStore`
- wrap store in `#if canImport(Combine) && canImport(SwiftUI)` and add Linux guard
- include `Core/Stores` in the package target
- add `EnvironmentsStoreTests` verifying load/save and selection validation

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_b_683affaba26c832694867ddf51089165