### PR TITLE
Add EnvironmentsStore persistence tests

### DIFF
--- a/Cantinarr/Core/Helpers/KeychainHelper.swift
+++ b/Cantinarr/Core/Helpers/KeychainHelper.swift
@@ -2,8 +2,11 @@
 // Purpose: Defines KeychainHelper component for Cantinarr
 
 import Foundation
+#if canImport(Security)
 import Security
+#endif
 
+#if canImport(Security)
 class KeychainHelper {
     /// Save sensitive data (e.g., API keys) to the Keychain.
     /// Data is stored with `kSecAttrAccessibleAfterFirstUnlock` so it remains
@@ -48,3 +51,12 @@ class KeychainHelper {
         return SecItemDelete(query as CFDictionary)
     }
 }
+#else
+typealias OSStatus = Int32
+
+class KeychainHelper {
+    static func save(key _: String, data _: Data) -> OSStatus { 0 }
+    static func load(key _: String) -> Data? { nil }
+    @discardableResult static func delete(key _: String) -> OSStatus { 0 }
+}
+#endif

--- a/Package.swift
+++ b/Package.swift
@@ -15,10 +15,16 @@ let package = Package(
             path: "Cantinarr",
             exclude: [
                 "Core/Models/UserSession.swift",
-                "Core/Models/RadarrSettings.swift"
+                "Core/Helpers/PagedLoader.swift",
+                "Core/Helpers/Shimmer.swift",
+                "Core/Helpers/WebView.swift",
+                "Core/Helpers/OverseerrAuthContextProvider.swift",
+                "Core/Helpers/OverseerrPlexSSODelegate.swift"
             ],
             sources: [
                 "Core/Models",
+                "Core/Stores",
+                "Core/Helpers",
                 "Features/Radarr/Models",
                 "Features/OverseerrUsers/Models"
             ]

--- a/Tests/EnvironmentsStoreTests.swift
+++ b/Tests/EnvironmentsStoreTests.swift
@@ -1,0 +1,41 @@
+import XCTest
+@testable import CantinarrModels
+
+#if canImport(Combine) && canImport(SwiftUI)
+final class EnvironmentsStoreTests: XCTestCase {
+    func testLoadSaveAndValidateSelections() throws {
+        // Use a unique temporary directory for isolation
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        let fileURL = tempDir.appendingPathComponent("env.json")
+
+        // Initial store writes data to disk
+        let store = EnvironmentsStore(fileURL: fileURL)
+        var env = ServerEnvironment(name: "Demo")
+        let svc = ServiceInstance(kind: .overseerrUsers, displayName: "Demo Service")
+        env.services = [svc]
+        store.environments = [env]
+        store.selectedEnvironmentID = env.id
+        store.selectedServiceID = svc.id
+        try store.saveNow()
+
+        // Loading a new instance should restore the environments
+        let loaded = EnvironmentsStore(fileURL: fileURL)
+        XCTAssertEqual(loaded.environments.count, 1)
+        XCTAssertEqual(loaded.environments.first?.name, "Demo")
+
+        // ValidateSelections adjusts service when removed
+        loaded.selectedEnvironmentID = loaded.environments.first!.id
+        loaded.selectedServiceID = loaded.environments.first!.services.first!.id
+        loaded.environments[0].services.removeAll()
+        loaded.validateSelections()
+        XCTAssertNil(loaded.selectedServiceID)
+
+        // Removing all environments clears selection
+        loaded.environments.removeAll()
+        loaded.validateSelections()
+        XCTAssertNil(loaded.selectedServiceID)
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- expose a `saveNow` helper and allow custom save location in `EnvironmentsStore`
- wrap store in `#if canImport(Combine) && canImport(SwiftUI)` and add Linux guard
- include `Core/Stores` in the package target
- add `EnvironmentsStoreTests` verifying load/save and selection validation
- include KeychainHelper with a Linux stub

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_b_683affaba26c832694867ddf51089165