### PR TITLE
Add EnvironmentsStore persistence tests

### DIFF
--- a/Cantinarr/Core/Helpers/KeychainHelper.swift
+++ b/Cantinarr/Core/Helpers/KeychainHelper.swift
@@ -2,8 +2,11 @@
 // Purpose: Defines KeychainHelper component for Cantinarr
 
 import Foundation
+
+#if canImport(Security)
 import Security
 
+/// Wrapper around the Security framework for storing small secrets.
 class KeychainHelper {
     /// Save sensitive data (e.g., API keys) to the Keychain.
     /// Data is stored with `kSecAttrAccessibleAfterFirstUnlock` so it remains
@@ -48,3 +51,19 @@ class KeychainHelper {
         return SecItemDelete(query as CFDictionary)
     }
 }
+
+#else
+
+/// Stubbed helper when Security is unavailable.
+/// Returns `0` for save/delete and always yields `nil` for load.
+typealias OSStatus = Int32
+
+class KeychainHelper {
+    @discardableResult
+    static func save(key: String, data: Data) -> OSStatus { 0 }
+    static func load(key: String) -> Data? { nil }
+    @discardableResult
+    static func delete(key: String) -> OSStatus { 0 }
+}
+
+#endif

--- a/Cantinarr/Core/Helpers/PagedLoader.swift
+++ b/Cantinarr/Core/Helpers/PagedLoader.swift
@@ -3,6 +3,7 @@
 
 //  Encapsulates generic paging counters + guard logic.
 
+#if canImport(SwiftUI)
 import SwiftUI
 
 /// Utility that tracks paging state for infinite‑scroll style lists.
@@ -40,3 +41,4 @@ struct PagedLoader {
         // Current implementation keeps page number, assuming retry will use the same page.
     }
 }
+#endif

--- a/Package.swift
+++ b/Package.swift
@@ -15,10 +15,15 @@ let package = Package(
             path: "Cantinarr",
             exclude: [
                 "Core/Models/UserSession.swift",
-                "Core/Models/RadarrSettings.swift"
+                "Core/Helpers/OverseerrAuthContextProvider.swift",
+                "Core/Helpers/OverseerrPlexSSODelegate.swift",
+                "Core/Helpers/Shimmer.swift",
+                "Core/Helpers/WebView.swift"
             ],
             sources: [
                 "Core/Models",
+                "Core/Helpers",
+                "Core/Stores",
                 "Features/Radarr/Models",
                 "Features/OverseerrUsers/Models"
             ]

--- a/Tests/EnvironmentsStoreTests.swift
+++ b/Tests/EnvironmentsStoreTests.swift
@@ -1,0 +1,41 @@
+import XCTest
+@testable import CantinarrModels
+
+#if canImport(Combine) && canImport(SwiftUI)
+final class EnvironmentsStoreTests: XCTestCase {
+    func testLoadSaveAndValidateSelections() throws {
+        // Use a unique temporary directory for isolation
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        let fileURL = tempDir.appendingPathComponent("env.json")
+
+        // Initial store writes data to disk
+        let store = EnvironmentsStore(fileURL: fileURL)
+        var env = ServerEnvironment(name: "Demo")
+        let svc = ServiceInstance(kind: .overseerrUsers, displayName: "Demo Service")
+        env.services = [svc]
+        store.environments = [env]
+        store.selectedEnvironmentID = env.id
+        store.selectedServiceID = svc.id
+        try store.saveNow()
+
+        // Loading a new instance should restore the environments
+        let loaded = EnvironmentsStore(fileURL: fileURL)
+        XCTAssertEqual(loaded.environments.count, 1)
+        XCTAssertEqual(loaded.environments.first?.name, "Demo")
+
+        // ValidateSelections adjusts service when removed
+        loaded.selectedEnvironmentID = loaded.environments.first!.id
+        loaded.selectedServiceID = loaded.environments.first!.services.first!.id
+        loaded.environments[0].services.removeAll()
+        loaded.validateSelections()
+        XCTAssertNil(loaded.selectedServiceID)
+
+        // Removing all environments clears selection
+        loaded.environments.removeAll()
+        loaded.validateSelections()
+        XCTAssertNil(loaded.selectedServiceID)
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- expose a `saveNow` helper and allow custom save location in `EnvironmentsStore`
- wrap store in `#if canImport(Combine) && canImport(SwiftUI)` and add Linux guard
- include `Core/Stores` in the package target
- add `EnvironmentsStoreTests` verifying load/save and selection validation
- provide stub `KeychainHelper` for non-Apple platforms and gate SwiftUI helper

## Testing
- `swift test --disable-sandbox`


------
https://chatgpt.com/codex/tasks/task_b_683affaba26c832694867ddf51089165