### PR TITLE
Add OverseerrAuthManager mocked tests

### DIFF
--- a/Cantinarr/Core/Auth/OverseerrAuthManager.swift
+++ b/Cantinarr/Core/Auth/OverseerrAuthManager.swift
@@ -1,8 +1,10 @@
 // File: OverseerrAuthManager.swift
 // Purpose: Defines OverseerrAuthManager component for Cantinarr
 
-import Combine
 import Foundation
+
+#if canImport(Combine)
+import Combine
 
 /// Actor = thread‑safe without extra locks.
 actor OverseerrAuthManager {
@@ -73,3 +75,4 @@ actor OverseerrAuthManager {
         await probeSession()
     }
 }
+#endif

--- a/Cantinarr/Core/Auth/OverseerrAuthState.swift
+++ b/Cantinarr/Core/Auth/OverseerrAuthState.swift
@@ -2,7 +2,9 @@
 // Purpose: Defines OverseerrAuthState component for Cantinarr
 
 import Foundation
+#if canImport(SwiftUI)
 import SwiftUI
+#endif
 
 /// Single source of truth for Overseerr session state.
 enum OverseerrAuthState: Equatable {

--- a/Cantinarr/Features/OverseerrUsers/MediaDetail/Models/MediaAvailability.swift
+++ b/Cantinarr/Features/OverseerrUsers/MediaDetail/Models/MediaAvailability.swift
@@ -1,7 +1,9 @@
 // File: MediaAvailability.swift
 // Purpose: Defines MediaAvailability component for Cantinarr
 
+#if canImport(SwiftUI)
 import SwiftUI
+#endif
 
 enum MediaAvailability: Int, Codable {
     case unknown = 1
@@ -22,6 +24,7 @@ enum MediaAvailability: Int, Codable {
         }
     }
 
+#if canImport(SwiftUI)
     /// Brand colours that match Overseerr’s UI.
     var tint: Color {
         switch self {
@@ -33,4 +36,5 @@ enum MediaAvailability: Int, Codable {
         case .deleted: .red
         }
     }
+#endif
 }

--- a/Package.swift
+++ b/Package.swift
@@ -18,14 +18,22 @@ let package = Package(
                 "Core/Helpers/OverseerrAuthContextProvider.swift",
                 "Core/Helpers/OverseerrPlexSSODelegate.swift",
                 "Core/Helpers/Shimmer.swift",
-                "Core/Helpers/WebView.swift"
+                "Core/Helpers/WebView.swift",
+                "Features/OverseerrUsers/Networking/OverseerrAPIService.swift",
+                "Features/OverseerrUsers/Networking/OverseerrAPIService+Authentication.swift",
+                "Features/OverseerrUsers/Networking/OverseerrAPIService+MediaDetail.swift",
+                "Features/OverseerrUsers/Networking/OverseerrAPIService+Discover.swift",
+                "Features/OverseerrUsers/Networking/OverseerrUsersService.swift"
             ],
             sources: [
                 "Core/Models",
                 "Core/Helpers",
                 "Core/Stores",
+                "Core/Auth",
                 "Features/Radarr/Models",
-                "Features/OverseerrUsers/Models"
+                "Features/OverseerrUsers/Models",
+                "Features/OverseerrUsers/MediaDetail/Models",
+                "Features/OverseerrUsers/Networking"
             ]
         ),
         .testTarget(

--- a/Tests/OverseerrAuthManagerTests.swift
+++ b/Tests/OverseerrAuthManagerTests.swift
@@ -1,0 +1,89 @@
+import XCTest
+@testable import CantinarrModels
+
+#if canImport(Combine) && canImport(SwiftUI)
+import Combine
+
+private actor MockOverseerrService: OverseerrServiceType {
+    private var isAuthenticatedResult: Bool = false
+    private(set) var isAuthenticatedCallCount = 0
+
+    func setIsAuthenticatedResult(_ value: Bool) {
+        isAuthenticatedResult = value
+    }
+
+    func getIsAuthenticatedCallCount() -> Int { isAuthenticatedCallCount }
+
+    func isAuthenticated() async -> Bool {
+        isAuthenticatedCallCount += 1
+        return isAuthenticatedResult
+    }
+
+    func fetchTrending(providerIds: [Int], page: Int) async throws -> DiscoverResponse<TrendingItem> {
+        fatalError("Not implemented")
+    }
+
+    func movieDetail(id: Int) async throws -> MovieDetail {
+        fatalError("Not implemented")
+    }
+
+    func tvDetail(id: Int) async throws -> TVDetail {
+        fatalError("Not implemented")
+    }
+
+    func request(mediaId id: Int, isMovie: Bool) async throws {
+        fatalError("Not implemented")
+    }
+
+    func reportIssue(mediaId id: Int, type: String, message: String) async throws {
+        fatalError("Not implemented")
+    }
+}
+
+final class OverseerrAuthManagerTests: XCTestCase {
+    func testEnsureAuthenticatedPublishesAuthenticatedAndThrottles() async {
+        let service = await MockOverseerrService()
+        await service.setIsAuthenticatedResult(true)
+
+        await OverseerrAuthManager.shared.configure(service: service)
+        // Wait for initial probe to finish
+        try? await Task.sleep(nanoseconds: 50_000_000)
+        let initialCount = await service.getIsAuthenticatedCallCount()
+
+        await OverseerrAuthManager.shared.ensureAuthenticated()
+        XCTAssertEqual(OverseerrAuthManager.shared.value, .authenticated(expiry: nil))
+        let firstCount = await service.getIsAuthenticatedCallCount()
+        XCTAssertEqual(firstCount, initialCount + 1)
+
+        await OverseerrAuthManager.shared.ensureAuthenticated()
+        let secondCount = await service.getIsAuthenticatedCallCount()
+        XCTAssertEqual(secondCount, firstCount)
+    }
+
+    func testRecoverFromAuthFailureResetsAndProbes() async {
+        let service = await MockOverseerrService()
+        await service.setIsAuthenticatedResult(true)
+
+        await OverseerrAuthManager.shared.configure(service: service)
+        await OverseerrAuthManager.shared.ensureAuthenticated()
+        let initialCount = await service.getIsAuthenticatedCallCount()
+
+        let exp = expectation(description: "states")
+        exp.expectedFulfillmentCount = 2
+        var states: [OverseerrAuthState] = []
+        let cancellable = OverseerrAuthManager.shared.publisher.dropFirst().sink { state in
+            states.append(state)
+            if states.count == 2 { exp.fulfill() }
+        }
+
+        Task { await OverseerrAuthManager.shared.recoverFromAuthFailure() }
+        await fulfillment(of: [exp], timeout: 1)
+        cancellable.cancel()
+
+        XCTAssertEqual(states.first, .unknown)
+        XCTAssertEqual(states.last, .authenticated(expiry: nil))
+        let finalCount = await service.getIsAuthenticatedCallCount()
+        XCTAssertEqual(finalCount, initialCount + 1)
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- expose auth code and service protocol to SwiftPM
- gate auth manager and models for non-Apple platforms
- add mocked `OverseerrAuthManagerTests`

## Testing
- `swift test --disable-sandbox`
- `swift test --filter OverseerrAuthManagerTests --enable-test-discovery`


------
https://chatgpt.com/codex/tasks/task_b_683b536b1bf8832685fdd9d9dd307dce