### PR TITLE
Add OverseerrAuthManager tests and gate platform code

### DIFF
--- a/Cantinarr/Core/Auth/OverseerrAuthManager.swift
+++ b/Cantinarr/Core/Auth/OverseerrAuthManager.swift
@@ -1,12 +1,10 @@
-// File: OverseerrAuthManager.swift
-// Purpose: Defines OverseerrAuthManager component for Cantinarr
-
-import Combine
+#if canImport(Combine)
 import Foundation
+import Combine
 
 /// Actor = thread‑safe without extra locks.
 actor OverseerrAuthManager {
-    // MARK: – Public singleton
+    // MARK: – Public singleton
 
     static let shared = OverseerrAuthManager()
     private init() {}
@@ -73,3 +71,4 @@ actor OverseerrAuthManager {
         await probeSession()
     }
 }
+#endif

--- a/Cantinarr/Core/Auth/OverseerrAuthState.swift
+++ b/Cantinarr/Core/Auth/OverseerrAuthState.swift
@@ -2,7 +2,9 @@
 // Purpose: Defines OverseerrAuthState component for Cantinarr
 
 import Foundation
+#if canImport(SwiftUI)
 import SwiftUI
+#endif
 
 /// Single source of truth for Overseerr session state.
 enum OverseerrAuthState: Equatable {

--- a/Cantinarr/Features/OverseerrUsers/MediaDetail/Models/MediaAvailability.swift
+++ b/Cantinarr/Features/OverseerrUsers/MediaDetail/Models/MediaAvailability.swift
@@ -1,7 +1,10 @@
 // File: MediaAvailability.swift
 // Purpose: Defines MediaAvailability component for Cantinarr
 
+import Foundation
+#if canImport(SwiftUI)
 import SwiftUI
+#endif
 
 enum MediaAvailability: Int, Codable {
     case unknown = 1
@@ -23,6 +26,7 @@ enum MediaAvailability: Int, Codable {
     }
 
     /// Brand colours that match Overseerr’s UI.
+#if canImport(SwiftUI)
     var tint: Color {
         switch self {
         case .unknown: .gray
@@ -33,4 +37,5 @@ enum MediaAvailability: Int, Codable {
         case .deleted: .red
         }
     }
+#endif
 }

--- a/Package.swift
+++ b/Package.swift
@@ -24,8 +24,11 @@ let package = Package(
                 "Core/Models",
                 "Core/Helpers",
                 "Core/Stores",
+                "Core/Auth",
                 "Features/Radarr/Models",
-                "Features/OverseerrUsers/Models"
+                "Features/OverseerrUsers/Models",
+                "Features/OverseerrUsers/MediaDetail/Models",
+                "Features/OverseerrUsers/Networking/OverseerrServiceType.swift"
             ]
         ),
         .testTarget(

--- a/Tests/OverseerrAuthManagerTests.swift
+++ b/Tests/OverseerrAuthManagerTests.swift
@@ -1,0 +1,68 @@
+#if canImport(Combine)
+import XCTest
+@testable import CantinarrModels
+
+@MainActor
+final class OverseerrAuthManagerTests: XCTestCase {
+    final class MockService: OverseerrServiceType {
+        var authResult: Bool
+        var authCallCount = 0
+        init(authResult: Bool) { self.authResult = authResult }
+        func isAuthenticated() async -> Bool {
+            authCallCount += 1
+            return authResult
+        }
+        func fetchTrending(providerIds: [Int], page: Int) async throws -> DiscoverResponse<TrendingItem> { fatalError("not used") }
+        func movieDetail(id: Int) async throws -> MovieDetail { fatalError("not used") }
+        func tvDetail(id: Int) async throws -> TVDetail { fatalError("not used") }
+        func request(mediaId id: Int, isMovie: Bool) async throws { fatalError("not used") }
+        func reportIssue(mediaId id: Int, type: String, message: String) async throws { fatalError("not used") }
+    }
+
+    override func tearDown() {
+        OverseerrAuthManager.shared.subject.send(.unknown)
+    }
+
+    func testProbeSessionAuthenticated() async {
+        let service = MockService(authResult: true)
+        let manager = OverseerrAuthManager.shared
+        await manager.configure(service: service)
+        await Task.yield()
+        await manager.probeSession()
+        XCTAssertEqual(manager.value, .authenticated(expiry: nil))
+        XCTAssertEqual(service.authCallCount, 2)
+    }
+
+    func testProbeSessionUnauthenticated() async {
+        let service = MockService(authResult: false)
+        let manager = OverseerrAuthManager.shared
+        await manager.configure(service: service)
+        await Task.yield()
+        await manager.probeSession()
+        XCTAssertEqual(manager.value, .unauthenticated)
+        XCTAssertEqual(service.authCallCount, 2)
+    }
+
+    func testEnsureAuthenticatedIsThrottled() async {
+        let service = MockService(authResult: true)
+        let manager = OverseerrAuthManager.shared
+        await manager.configure(service: service)
+        await Task.yield()
+        service.authCallCount = 0
+        await manager.ensureAuthenticated()
+        XCTAssertEqual(service.authCallCount, 1)
+        await manager.ensureAuthenticated()
+        XCTAssertEqual(service.authCallCount, 1)
+    }
+
+    func testRecoverFromAuthFailureTransitionsState() async {
+        let service = MockService(authResult: true)
+        let manager = OverseerrAuthManager.shared
+        await manager.configure(service: service)
+        await Task.yield()
+        manager.subject.send(.unauthenticated)
+        await manager.recoverFromAuthFailure()
+        XCTAssertEqual(manager.value, .authenticated(expiry: nil))
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- include auth models and protocol in Swift package
- gate OverseerrAuthManager, OverseerrAuthState, and MediaAvailability for platforms with Combine/SwiftUI
- add tests for OverseerrAuthManager (run only where Combine is available)
- update tests to await actor calls and handle automatic probes

## Testing
- `swift test -v`

------
https://chatgpt.com/codex/tasks/task_b_683b69a7f430832688edc6c523beb1f5