### PR TITLE
Fix ensureAuthenticated throttling test

### DIFF
--- a/Tests/OverseerrAuthManagerTests.swift
+++ b/Tests/OverseerrAuthManagerTests.swift
@@ -46,8 +46,7 @@ final class OverseerrAuthManagerTests: XCTestCase {
     func testEnsureAuthenticatedIsThrottled() async {
         let service = MockService(authResult: true)
         let manager = OverseerrAuthManager.shared
-        await manager.configure(service: service)
-        await Task.yield()
+        await manager.configure(service: service, autoProbe: false)
         service.authCallCount = 0
         await manager.ensureAuthenticated()
         XCTAssertEqual(service.authCallCount, 1)


### PR DESCRIPTION
## Summary
- disable auto-probe in ensureAuthenticated throttling test
- remove unnecessary `Task.yield()` call

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_b_683b844ae77083268f28a9327087958a