### PR TITLE
Update SwiftPM exclude paths

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,22 @@ let package = Package(
                 "Core/Helpers/OverseerrAuthContextProvider.swift",
                 "Core/Helpers/OverseerrPlexSSODelegate.swift",
                 "Core/Helpers/Shimmer.swift",
-                "Core/Helpers/WebView.swift"
+                "Core/Helpers/WebView.swift",
+                // Exclude SwiftUI and UI-related resources not used by SwiftPM
+                "App",
+                "Views",
+                "Navigation",
+                "Persistence",
+                "Assets.xcassets",
+                "Cantinarr.xcdatamodeld",
+                "LaunchScreen.storyboard",
+                "Features/Shared",
+                "Features/Shell",
+                "Features/Settings",
+                "Features/OverseerrUsers/UI",
+                "Features/OverseerrUsers/MediaDetail",
+                "Features/Radarr/UI",
+                "Features/Radarr/Logic"
             ],
             sources: [
                 "Core/Models",


### PR DESCRIPTION
## Summary
- expand the exclude paths in `Package.swift` so SwiftPM doesn't warn about unused SwiftUI resources

## Testing
- `swift test -v` *(fails: cannot find type 'TVDetail' in scope)*

------
https://chatgpt.com/codex/tasks/task_b_683b9b9f97d8832684b502c002c78fc0