### PR TITLE
Fix OverseerrError duplication

### DIFF
--- a/Cantinarr/Features/OverseerrUsers/Networking/OverseerrAPIService.swift
+++ b/Cantinarr/Features/OverseerrUsers/Networking/OverseerrAPIService.swift
@@ -8,28 +8,8 @@ import WebKit
 /// Shared cookie store so that WKWebView and URLSession share authentication cookies.
 private let sharedDataStore = WKWebsiteDataStore.default()
 
-/// Errors specific to Overseerr API interactions.
-enum OverseerrError: Error, LocalizedError {
-    case notAuthenticated
-    case apiError(message: String, statusCode: Int)
-    case invalidResponse
-    case network(Error)
-
-    var errorDescription: String? {
-        switch self {
-        case .notAuthenticated:
-            return "Authentication required."
-        case let .apiError(message, _):
-            return message
-        case .invalidResponse:
-            return "Invalid response from server."
-        case let .network(error):
-            return error.localizedDescription
-        }
-    }
-}
-
-
+// OverseerrError lives in Models/OverseerrError.swift
+// keeping networking code focused on API requests.
 @MainActor
 class OverseerrAPIService {
     // MARK: – Configuration


### PR DESCRIPTION
## Summary
- keep `OverseerrError` in its own model file
- clean up API service by removing duplicate enum

## Testing
- `swift build --product CantinarrModels`
- `swift test`

------
https://chatgpt.com/codex/tasks/task_b_683ba20502408326b8a505f98ac9e189