### PR TITLE
Add side menu gesture tests

### DIFF
--- a/Cantinarr/Features/Shell/RootShellView.swift
+++ b/Cantinarr/Features/Shell/RootShellView.swift
@@ -1,6 +1,7 @@
 // File: RootShellView.swift
 // Purpose: Defines RootShellView component for Cantinarr
 
+#if canImport(SwiftUI)
 import SwiftUI
 
 /// The global frame: a slide‑out sidebar on the left + a detail pane.
@@ -158,3 +159,4 @@ struct RootShellView: View {
         }
     }
 }
+#endif

--- a/Cantinarr/Features/Shell/SideMenuGestureManager.swift
+++ b/Cantinarr/Features/Shell/SideMenuGestureManager.swift
@@ -1,6 +1,7 @@
 // File: SideMenuGestureManager.swift
 // Purpose: Encapsulates drag and tap gestures for the side menu
 
+#if canImport(SwiftUI)
 import SwiftUI
 
 /// Handles the gestures that control the slide-out side menu.
@@ -18,11 +19,21 @@ struct SideMenuGestureManager {
     /// Points the user must drag horizontally before the menu toggles.
     var dragThreshold: CGFloat = 40
 
+    /// Returns true if the drag should open the menu for a given translation.
+    func shouldOpen(for translation: CGSize) -> Bool {
+        translation.width > dragThreshold
+    }
+
+    /// Returns true if the drag should close the menu for a given translation.
+    func shouldClose(for translation: CGSize) -> Bool {
+        translation.width < -dragThreshold
+    }
+
     /// Dragging right past `dragThreshold` opens the menu.
     func openDragGesture() -> some Gesture {
         DragGesture(minimumDistance: minDragDistance)
             .onEnded { value in
-                if value.translation.width > dragThreshold {
+                if shouldOpen(for: value.translation) {
                     openMenu()
                 }
             }
@@ -32,7 +43,7 @@ struct SideMenuGestureManager {
     func closeDragGesture() -> some Gesture {
         DragGesture(minimumDistance: minDragDistance)
             .onEnded { value in
-                if value.translation.width < -dragThreshold {
+                if shouldClose(for: value.translation) {
                     closeMenu()
                 }
             }
@@ -43,3 +54,4 @@ struct SideMenuGestureManager {
         TapGesture().onEnded { closeMenu() }
     }
 }
+#endif

--- a/Cantinarr/Features/Shell/UI/SideMenuView.swift
+++ b/Cantinarr/Features/Shell/UI/SideMenuView.swift
@@ -1,6 +1,7 @@
 // File: SideMenuView.swift
 // Purpose: Defines SideMenuView component for Cantinarr
 
+#if canImport(SwiftUI)
 import SwiftUI
 
 /// Drawer content: gear, services, utilities, env‑picker.
@@ -66,3 +67,4 @@ struct SideMenuView: View {
         )
     }
 }
+#endif

--- a/Package.swift
+++ b/Package.swift
@@ -28,7 +28,8 @@ let package = Package(
                 "Cantinarr.xcdatamodeld",
                 "LaunchScreen.storyboard",
                 "Features/Shared",
-                "Features/Shell",
+                "Features/Shell/RootShellView.swift",
+                "Features/Shell/UI/SideMenuView.swift",
                 "Features/Settings",
                 "Features/OverseerrUsers/UI",
                 "Features/OverseerrUsers/MediaDetail/UI",
@@ -48,7 +49,8 @@ let package = Package(
                 "Features/OverseerrUsers/Networking/OverseerrServiceType.swift",
                 "Features/OverseerrUsers/Logic/FilterManager.swift",
                 "Features/OverseerrUsers/Logic/SearchController.swift",
-                "Features/OverseerrUsers/Networking/OverseerrUsersService.swift"
+                "Features/OverseerrUsers/Networking/OverseerrUsersService.swift",
+                "Features/Shell/SideMenuGestureManager.swift"
             ]
         ),
         .testTarget(

--- a/Tests/SideMenuGestureManagerTests.swift
+++ b/Tests/SideMenuGestureManagerTests.swift
@@ -1,0 +1,18 @@
+#if canImport(Combine) && canImport(SwiftUI)
+import XCTest
+@testable import CantinarrModels
+
+final class SideMenuGestureManagerTests: XCTestCase {
+    func testShouldOpenWhenDraggedPastThreshold() {
+        let mgr = SideMenuGestureManager(openMenu: {}, closeMenu: {}, dragThreshold: 40)
+        XCTAssertTrue(mgr.shouldOpen(for: CGSize(width: 41, height: 0)))
+        XCTAssertFalse(mgr.shouldOpen(for: CGSize(width: 30, height: 0)))
+    }
+
+    func testShouldCloseWhenDraggedPastThreshold() {
+        let mgr = SideMenuGestureManager(openMenu: {}, closeMenu: {}, dragThreshold: 40)
+        XCTAssertTrue(mgr.shouldClose(for: CGSize(width: -41, height: 0)))
+        XCTAssertFalse(mgr.shouldClose(for: CGSize(width: -30, height: 0)))
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- improve cross-platform safety with SwiftUI guards
- expose SideMenuGestureManager behavior with new helpers
- test drag threshold helpers
- include the manager in the Swift package

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_b_683bb9ae59a48326bbf0cd24bd660816