### PR TITLE
Remove Combine requirement from RadarrAPIService

### DIFF
--- a/Cantinarr/Features/Radarr/RadarrAPIService.swift
+++ b/Cantinarr/Features/Radarr/RadarrAPIService.swift
@@ -1,12 +1,11 @@
 // File: RadarrAPIService.swift
 // Purpose: Defines RadarrAPIService component for Cantinarr
 
-import Combine // Import Combine for ObservableObject
 import Foundation
 
 /// Networking layer for communicating with a Radarr instance.
 @MainActor
-class RadarrAPIService: ObservableObject { // ADDED ObservableObject conformance
+class RadarrAPIService {
     private let settings: RadarrSettings
     private let baseURL: URL
     private let session: URLSession


### PR DESCRIPTION
## Summary
- drop `ObservableObject` conformance from `RadarrAPIService`
- remove unused `Combine` import

## Testing
- `swift build`
- `swift test`


------
https://chatgpt.com/codex/tasks/task_b_683bdb350c6483269849e16c46798830