### PR TITLE
Add Equatable support for media views

### DIFF
--- a/Cantinarr/Features/OverseerrUsers/Models/MediaItem.swift
+++ b/Cantinarr/Features/OverseerrUsers/Models/MediaItem.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// Lightweight display model for movies and shows in lists.
-struct MediaItem: Identifiable {
+struct MediaItem: Identifiable, Equatable {
     let id: Int
     let title: String
     let posterPath: String?

--- a/Cantinarr/Features/OverseerrUsers/UI/MediaCardView.swift
+++ b/Cantinarr/Features/OverseerrUsers/UI/MediaCardView.swift
@@ -4,7 +4,7 @@
 import NukeUI
 import SwiftUI
 
-struct MediaCardView: View {
+struct MediaCardView: View, Equatable {
     let id: Int
     let mediaType: MediaType
     let title: String
@@ -76,5 +76,12 @@ struct MediaCardView: View {
                 .multilineTextAlignment(.center)
                 .frame(maxWidth: .infinity)
         }
+    }
+
+    static func == (lhs: MediaCardView, rhs: MediaCardView) -> Bool {
+        lhs.id == rhs.id &&
+        lhs.mediaType == rhs.mediaType &&
+        lhs.title == rhs.title &&
+        lhs.posterPath == rhs.posterPath
     }
 }

--- a/Cantinarr/Features/OverseerrUsers/UI/OverseerrUsersAdvancedView.swift
+++ b/Cantinarr/Features/OverseerrUsers/UI/OverseerrUsersAdvancedView.swift
@@ -219,6 +219,7 @@ private struct SearchResultsSection: View {
                                       mediaType: item.mediaType,
                                       title: item.title,
                                       posterPath: item.posterPath)
+                            .equatable()
                             .onAppear { loadMore(item) }
                     }
                 }
@@ -233,6 +234,7 @@ private struct SearchResultsSection: View {
                     if (isSearchLoadingLocal || isLoadingSearch) && results.isEmpty {
                         HorizontalItemRow(items: [MediaItem](), isLoading: true, onAppear: { _ in }) { _ in
                             MediaCardView(id: 0, mediaType: .movie, title: "", posterPath: nil)
+                                .equatable()
                                 .frame(width: 110)
                         } placeholder: {
                             LoadingCardView()
@@ -261,6 +263,7 @@ private struct SearchResultsSection: View {
                                           mediaType: item.mediaType,
                                           title: item.title,
                                           posterPath: item.posterPath)
+                                .equatable()
                                 .frame(width: 110)
                         } placeholder: {
                             LoadingCardView()
@@ -331,6 +334,7 @@ private struct RecommendationRowsView: View {
                                   mediaType: item.mediaType,
                                   title: item.title,
                                   posterPath: item.posterPath)
+                        .equatable()
                         .frame(width: 110)
                 } placeholder: {
                     LoadingCardView()
@@ -349,6 +353,7 @@ private struct RecommendationRowsView: View {
                                   mediaType: item.mediaType,
                                   title: item.title,
                                   posterPath: item.posterPath)
+                        .equatable()
                         .frame(width: 110)
                 } placeholder: {
                     LoadingCardView()

--- a/Cantinarr/Features/OverseerrUsers/UI/OverseerrUsersHomeView.swift
+++ b/Cantinarr/Features/OverseerrUsers/UI/OverseerrUsersHomeView.swift
@@ -216,6 +216,7 @@ struct OverseerrUsersHomeView: View {
                 Text("Movies You Might Like").font(.headline).padding(.horizontal).opacity(0) // Placeholder title
                 HorizontalItemRow(items: [MediaItem](), isLoading: true, onAppear: { _ in }) { _ in
                     MediaCardView(id: 0, mediaType: .movie, title: "", posterPath: nil)
+                        .equatable()
                         .frame(width: 110)
                 } placeholder: {
                     LoadingCardView()
@@ -233,6 +234,7 @@ struct OverseerrUsersHomeView: View {
                                   mediaType: item.mediaType,
                                   title: item.title,
                                   posterPath: item.posterPath)
+                        .equatable()
                         .frame(width: 110)
                 } placeholder: {
                     LoadingCardView()
@@ -244,6 +246,7 @@ struct OverseerrUsersHomeView: View {
                 Text("Shows You Might Like").font(.headline).padding(.horizontal).opacity(0) // Placeholder title
                 HorizontalItemRow(items: [MediaItem](), isLoading: true, onAppear: { _ in }) { _ in
                     MediaCardView(id: 0, mediaType: .movie, title: "", posterPath: nil)
+                        .equatable()
                         .frame(width: 110)
                 } placeholder: {
                     LoadingCardView()
@@ -261,6 +264,7 @@ struct OverseerrUsersHomeView: View {
                                   mediaType: item.mediaType,
                                   title: item.title,
                                   posterPath: item.posterPath)
+                        .equatable()
                         .frame(width: 110)
                 } placeholder: {
                     LoadingCardView()
@@ -306,6 +310,7 @@ private struct TrendingDisplayView: View {
                 .opacity(0)
             HorizontalItemRow(items: [MediaItem](), isLoading: true, onAppear: { _ in }) { _ in
                 MediaCardView(id: 0, mediaType: .movie, title: "", posterPath: nil)
+                    .equatable()
                     .frame(width: 110)
             } placeholder: {
                 LoadingCardView()
@@ -322,6 +327,7 @@ private struct TrendingDisplayView: View {
                               mediaType: item.mediaType,
                               title: item.title,
                               posterPath: item.posterPath)
+                    .equatable()
                     .frame(width: 110)
             } placeholder: {
                 LoadingCardView()
@@ -353,6 +359,7 @@ private struct SearchResultsRowView: View {
                 .opacity(0)
             HorizontalItemRow(items: [MediaItem](), isLoading: true, onAppear: { _ in }) { _ in
                 MediaCardView(id: 0, mediaType: .movie, title: "", posterPath: nil)
+                    .equatable()
                     .frame(width: 110)
             } placeholder: {
                 LoadingCardView()
@@ -384,6 +391,7 @@ private struct SearchResultsRowView: View {
                               mediaType: item.mediaType,
                               title: item.title,
                               posterPath: item.posterPath)
+                    .equatable()
                     .frame(width: 110)
             } placeholder: {
                 LoadingCardView()


### PR DESCRIPTION
## Summary
- make `MediaItem` conform to `Equatable`
- conform `MediaCardView` to `Equatable`
- mark `MediaCardView` instances as `.equatable()` in `OverseerrUsersHomeView`
- do the same in `OverseerrUsersAdvancedView`

## Testing
- `swift test -c debug`

------
https://chatgpt.com/codex/tasks/task_b_683bdcbdc15483268c41ea1386fcf243