### PR TITLE
Configure image pipeline and resize images

### DIFF
--- a/Cantinarr/App/CantinarrApp.swift
+++ b/Cantinarr/App/CantinarrApp.swift
@@ -11,6 +11,10 @@ struct CantinarrApp: App {
 
     @StateObject private var environmentsStore = EnvironmentsStore()
 
+    init() {
+        ImagePipelineConfig.configureShared()
+    }
+
 
     // MARK: - Body
 

--- a/Cantinarr/Core/Configuration/ImagePipelineConfig.swift
+++ b/Cantinarr/Core/Configuration/ImagePipelineConfig.swift
@@ -1,0 +1,28 @@
+// File: ImagePipelineConfig.swift
+// Purpose: Defines ImagePipelineConfig component for Cantinarr
+
+#if canImport(Nuke)
+import Nuke
+
+/// Centralised configuration for the shared ``ImagePipeline`` instance.
+enum ImagePipelineConfig {
+    /// Configure ``ImagePipeline.shared`` with disk and memory caching.
+    static func configureShared() {
+        // Disk cache stored in Application Support
+        let dataCache = try? DataCache(name: "CantinarrImages")
+        dataCache?.sizeLimit = 200 * 1024 * 1024 // 200 MB
+
+        // In‑memory image cache
+        let imageCache = ImageCache()
+        imageCache.costLimit = 50 * 1024 * 1024 // ~50 MB
+
+        var config = ImagePipeline.Configuration()
+        config.dataCache = dataCache
+        config.imageCache = imageCache
+        config.isDeduplicationEnabled = true
+        config.isProgressiveDecodingEnabled = true
+
+        ImagePipeline.shared = ImagePipeline(configuration: config)
+    }
+}
+#endif

--- a/Cantinarr/Features/OverseerrUsers/MediaDetail/UI/MediaDetailView.swift
+++ b/Cantinarr/Features/OverseerrUsers/MediaDetail/UI/MediaDetailView.swift
@@ -27,9 +27,14 @@ struct MediaDetailView: View {
     // MARK: – Global blurred background
 
     @ViewBuilder
-    private var blurredBackground: some View {
+    private func blurredBackground(size: CGSize) -> some View {
         if let url = vm.backdropURL {
-            LazyImage(url: url) { state in
+            LazyImage(
+                request: ImageRequest(
+                    url: url,
+                    processors: [ImageProcessors.Resize(size: size, unit: .points)]
+                )
+            ) { state in
                 state.image?
                     .resizable()
                     .scaledToFill()
@@ -44,7 +49,7 @@ struct MediaDetailView: View {
 
     var body: some View {
         GeometryReader { rootGeo in
-            blurredBackground
+            blurredBackground(size: rootGeo.size)
             // Safe width & height the content is allowed to use
             let safeWidth = rootGeo.size.width
                 - rootGeo.safeAreaInsets.leading

--- a/Cantinarr/Features/OverseerrUsers/MediaDetail/UI/MediaHeaderView.swift
+++ b/Cantinarr/Features/OverseerrUsers/MediaDetail/UI/MediaHeaderView.swift
@@ -18,7 +18,17 @@ struct MediaHeaderView: View {
                            startPoint: .bottom, endPoint: .top)
             HStack(alignment: .bottom, spacing: 16) {
                 if let url = posterURL {
-                    LazyImage(url: url) { state in
+                    LazyImage(
+                        request: ImageRequest(
+                            url: url,
+                            processors: [
+                                ImageProcessors.Resize(
+                                    size: CGSize(width: 120, height: 180),
+                                    unit: .points
+                                ),
+                            ]
+                        )
+                    ) { state in
                         state.image?.resizable()
                             .scaledToFill()
                             .frame(width: 120, height: 180)
@@ -45,10 +55,17 @@ struct MediaHeaderView: View {
         }
         .background {
             if let url = backdropURL {
-                LazyImage(url: url) { state in
-                    state.image?.resizable()
-                        .scaledToFill()
-                        .overlay(Color.black.opacity(0.25))
+                GeometryReader { geo in
+                    LazyImage(
+                        request: ImageRequest(
+                            url: url,
+                            processors: [ImageProcessors.Resize(size: geo.size, unit: .points)]
+                        )
+                    ) { state in
+                        state.image?.resizable()
+                            .scaledToFill()
+                            .overlay(Color.black.opacity(0.25))
+                    }
                 }
             }
         }

--- a/Cantinarr/Features/OverseerrUsers/UI/MediaCardView.swift
+++ b/Cantinarr/Features/OverseerrUsers/UI/MediaCardView.swift
@@ -48,7 +48,17 @@ struct MediaCardView: View, Equatable {
     private var posterAndTitle: some View {
         VStack(spacing: 8) {
             if let url = posterURL {
-                LazyImage(url: url) { state in
+                LazyImage(
+                    request: ImageRequest(
+                        url: url,
+                        processors: [
+                            ImageProcessors.Resize(
+                                size: CGSize(width: 100, height: 150),
+                                unit: .points
+                            )
+                        ]
+                    )
+                ) { state in
                     if let img = state.image {
                         img.resizable()
                             .scaledToFill()

--- a/Cantinarr/Features/Radarr/UI/MovieHeaderView.swift
+++ b/Cantinarr/Features/Radarr/UI/MovieHeaderView.swift
@@ -14,7 +14,17 @@ struct MovieHeaderView: View {
                            startPoint: .bottom, endPoint: .center)
 
             HStack(alignment: .bottom, spacing: 16) {
-                LazyImage(url: movie.posterURL) { state in
+                LazyImage(
+                    request: ImageRequest(
+                        url: movie.posterURL,
+                        processors: [
+                            ImageProcessors.Resize(
+                                size: CGSize(width: 120, height: 180),
+                                unit: .points
+                            ),
+                        ]
+                    )
+                ) { state in
                     state.image?.resizable()
                         .scaledToFill()
                         .frame(width: 120, height: 180)
@@ -55,10 +65,17 @@ struct MovieHeaderView: View {
         }
         .background {
             if let url = movie.fanartURL {
-                LazyImage(url: url) { state in
-                    state.image?.resizable()
-                        .scaledToFill()
-                        .overlay(Color.black.opacity(0.3))
+                GeometryReader { geo in
+                    LazyImage(
+                        request: ImageRequest(
+                            url: url,
+                            processors: [ImageProcessors.Resize(size: geo.size, unit: .points)]
+                        )
+                    ) { state in
+                        state.image?.resizable()
+                            .scaledToFill()
+                            .overlay(Color.black.opacity(0.3))
+                    }
                 }
             }
         }

--- a/Cantinarr/Features/Radarr/UI/RadarrMovieDetailView.swift
+++ b/Cantinarr/Features/Radarr/UI/RadarrMovieDetailView.swift
@@ -25,9 +25,14 @@ struct RadarrMovieDetailView: View {
     }
 
     @ViewBuilder
-    private var blurredBackground: some View {
+    private func blurredBackground(size: CGSize) -> some View {
         if let url = viewModel.movie?.fanartURL {
-            LazyImage(url: url) { state in
+            LazyImage(
+                request: ImageRequest(
+                    url: url,
+                    processors: [ImageProcessors.Resize(size: size, unit: .points)]
+                )
+            ) { state in
                 state.image?
                     .resizable()
                     .scaledToFill()
@@ -42,7 +47,7 @@ struct RadarrMovieDetailView: View {
 
     var body: some View {
         GeometryReader { rootGeo in
-            blurredBackground
+            blurredBackground(size: rootGeo.size)
 
             let safeWidth = rootGeo.size.width - rootGeo.safeAreaInsets.leading - rootGeo.safeAreaInsets.trailing
             let safeHeight = rootGeo.size.height - rootGeo.safeAreaInsets.bottom

--- a/Cantinarr/Features/Radarr/UI/RadarrMovieListItemView.swift
+++ b/Cantinarr/Features/Radarr/UI/RadarrMovieListItemView.swift
@@ -50,7 +50,17 @@ struct RadarrMovieListItemView: View {
     var body: some View {
         HStack(alignment: .top, spacing: 12) {
             // Poster Image
-            LazyImage(url: movie.posterURL) { state in
+            LazyImage(
+                request: ImageRequest(
+                    url: movie.posterURL,
+                    processors: [
+                        ImageProcessors.Resize(
+                            size: CGSize(width: 80, height: 120),
+                            unit: .points
+                        ),
+                    ]
+                )
+            ) { state in
                 if let image = state.image {
                     image
                         .resizable()
@@ -115,29 +125,39 @@ struct RadarrMovieListItemView: View {
         }
         .padding(10)
         .background(
-            ZStack {
-                LazyImage(url: movie.fanartURL) { state in
-                    if let image = state.image {
-                        image
-                            .resizable()
-                            .aspectRatio(contentMode: .fill)
-                            .blur(radius: 3, opaque: true) // Opaque blur
-                    } else {
-                        Color.clear // Fallback if no fanart
+            GeometryReader { geo in
+                ZStack {
+                    LazyImage(
+                        request: ImageRequest(
+                            url: movie.fanartURL,
+                            processors: [
+                                ImageProcessors.Resize(size: geo.size, unit: .points)
+                            ]
+                        )
+                    ) { state in
+                        if let image = state.image {
+                            image
+                                .resizable()
+                                .aspectRatio(contentMode: .fill)
+                                .blur(radius: 3, opaque: true) // Opaque blur
+                        } else {
+                            Color.clear // Fallback if no fanart
+                        }
                     }
-                }
-                .scaleEffect(1.1) // Slightly zoom to ensure blur covers edges
-                .clipped()
+                    .scaleEffect(1.1) // Slightly zoom to ensure blur covers edges
+                    .clipped()
 
-                LinearGradient(
-                    gradient: Gradient(colors: [
-                        Color.black.opacity(0.75),
-                        Color.black.opacity(0.5),
-                        Color.black.opacity(0.75),
-                    ]),
-                    startPoint: .leading,
-                    endPoint: .trailing
-                )
+                    LinearGradient(
+                        gradient: Gradient(colors: [
+                            Color.black.opacity(0.75),
+                            Color.black.opacity(0.5),
+                            Color.black.opacity(0.75),
+                        ]),
+                        startPoint: .leading,
+                        endPoint: .trailing
+                    )
+                }
+                .frame(width: geo.size.width, height: geo.size.height)
             }
         )
         .cornerRadius(12)


### PR DESCRIPTION
## Summary
- add a shared ImagePipeline configuration
- set up the image pipeline when the app starts
- resize downloaded images to match view frames

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_b_683c639255d083268176844673b1af9d