### PR TITLE
Fix Nuke imports for image processing

### DIFF
--- a/Cantinarr/Features/OverseerrUsers/MediaDetail/UI/MediaDetailView.swift
+++ b/Cantinarr/Features/OverseerrUsers/MediaDetail/UI/MediaDetailView.swift
@@ -2,6 +2,7 @@
 // Purpose: Defines MediaDetailView component for Cantinarr
 
 import NukeUI
+import Nuke
 import SwiftUI
 
 struct MediaDetailView: View {

--- a/Cantinarr/Features/OverseerrUsers/MediaDetail/UI/MediaHeaderView.swift
+++ b/Cantinarr/Features/OverseerrUsers/MediaDetail/UI/MediaHeaderView.swift
@@ -1,4 +1,5 @@
 import NukeUI
+import Nuke
 import SwiftUI
 
 /// Header displaying poster, title and action buttons.

--- a/Cantinarr/Features/OverseerrUsers/UI/MediaCardView.swift
+++ b/Cantinarr/Features/OverseerrUsers/UI/MediaCardView.swift
@@ -2,6 +2,7 @@
 // Purpose: Defines MediaCardView component for Cantinarr
 
 import NukeUI
+import Nuke
 import SwiftUI
 
 struct MediaCardView: View, Equatable {

--- a/Cantinarr/Features/Radarr/UI/MovieHeaderView.swift
+++ b/Cantinarr/Features/Radarr/UI/MovieHeaderView.swift
@@ -1,4 +1,5 @@
 import NukeUI
+import Nuke
 import SwiftUI
 
 /// Header for the Radarr movie detail screen showing poster and basic info.

--- a/Cantinarr/Features/Radarr/UI/RadarrMovieDetailView.swift
+++ b/Cantinarr/Features/Radarr/UI/RadarrMovieDetailView.swift
@@ -2,6 +2,7 @@
 // Purpose: Defines RadarrMovieDetailView component for Cantinarr
 
 import NukeUI
+import Nuke
 import SwiftUI
 
 private struct TaglineHeightKeyRadarr: PreferenceKey {

--- a/Cantinarr/Features/Radarr/UI/RadarrMovieListItemView.swift
+++ b/Cantinarr/Features/Radarr/UI/RadarrMovieListItemView.swift
@@ -2,6 +2,7 @@
 // Purpose: Defines RadarrMovieListItemView component for Cantinarr
 
 import NukeUI
+import Nuke
 import SwiftUI
 
 /// Row in the movies list showing title, runtime and quality.


### PR DESCRIPTION
## Summary
- import the Nuke framework anywhere `ImageProcessors` is used

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_b_683c6eb136b0832687b016dc3c620c13