### PR TITLE
Remove deprecated Nuke deduplication config

### DIFF
--- a/Cantinarr/Core/Configuration/ImagePipelineConfig.swift
+++ b/Cantinarr/Core/Configuration/ImagePipelineConfig.swift
@@ -19,7 +19,6 @@ enum ImagePipelineConfig {
         var config = ImagePipeline.Configuration()
         config.dataCache = dataCache
         config.imageCache = imageCache
-        config.isDeduplicationEnabled = true
         config.isProgressiveDecodingEnabled = true
 
         ImagePipeline.shared = ImagePipeline(configuration: config)


### PR DESCRIPTION
## Summary
- update image pipeline settings by dropping obsolete deduplication flag

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_b_683c6e44a4648326b4f15e88d5bc585a