### PR TITLE
Fix header background resizing on scroll

### DIFF
--- a/Cantinarr/Features/OverseerrUsers/MediaDetail/UI/MediaHeaderView.swift
+++ b/Cantinarr/Features/OverseerrUsers/MediaDetail/UI/MediaHeaderView.swift
@@ -1,5 +1,4 @@
 import NukeUI
-import Nuke
 import SwiftUI
 
 /// Header displaying poster, title and action buttons.
@@ -19,17 +18,7 @@ struct MediaHeaderView: View {
                            startPoint: .bottom, endPoint: .top)
             HStack(alignment: .bottom, spacing: 16) {
                 if let url = posterURL {
-                    LazyImage(
-                        request: ImageRequest(
-                            url: url,
-                            processors: [
-                                ImageProcessors.Resize(
-                                    size: CGSize(width: 120, height: 180),
-                                    unit: .points
-                                ),
-                            ]
-                        )
-                    ) { state in
+                    LazyImage(url: url) { state in
                         state.image?.resizable()
                             .scaledToFill()
                             .frame(width: 120, height: 180)
@@ -56,17 +45,10 @@ struct MediaHeaderView: View {
         }
         .background {
             if let url = backdropURL {
-                GeometryReader { geo in
-                    LazyImage(
-                        request: ImageRequest(
-                            url: url,
-                            processors: [ImageProcessors.Resize(size: geo.size, unit: .points)]
-                        )
-                    ) { state in
-                        state.image?.resizable()
-                            .scaledToFill()
-                            .overlay(Color.black.opacity(0.25))
-                    }
+                LazyImage(url: url) { state in
+                    state.image?.resizable()
+                        .scaledToFill()
+                        .overlay(Color.black.opacity(0.25))
                 }
             }
         }


### PR DESCRIPTION
## Summary
- remove Nuke resize processing from `MediaHeaderView` background
- restore simpler LazyImage usage for header poster and backdrop

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_b_683c762f1be8832690156a10fad75cd4