### PR TITLE
Make auth state actor-isolated

### DIFF
--- a/Cantinarr/Core/Auth/OverseerrAuthManager.swift
+++ b/Cantinarr/Core/Auth/OverseerrAuthManager.swift
@@ -7,16 +7,24 @@ actor OverseerrAuthManager {
     // MARK: – Public singleton
 
     static let shared = OverseerrAuthManager()
-    private init() {}
 
-    // MARK: – Published state
+    let subject: CurrentValueSubject<OverseerrAuthState, Never>
+    nonisolated let publisher: AnyPublisher<OverseerrAuthState, Never>
+    var value: OverseerrAuthState { subject.value }
 
-    nonisolated let subject = CurrentValueSubject<OverseerrAuthState, Never>(.unknown)
-    nonisolated var publisher: AnyPublisher<OverseerrAuthState, Never> {
-        subject.eraseToAnyPublisher()
+    /// Async accessor for the current auth state.
+    func currentValue() -> OverseerrAuthState { value }
+
+    /// Directly update the auth state. Intended for testing.
+    func setState(_ newState: OverseerrAuthState) {
+        subject.send(newState)
     }
 
-    nonisolated var value: OverseerrAuthState { subject.value }
+    private init() {
+        let subj = CurrentValueSubject<OverseerrAuthState, Never>(.unknown)
+        subject = subj
+        publisher = subj.eraseToAnyPublisher()
+    }
 
     // MARK: – Config injected once at app launch
 

--- a/Cantinarr/Features/OverseerrUsers/Logic/OverseerrUsersViewModel.swift
+++ b/Cantinarr/Features/OverseerrUsers/Logic/OverseerrUsersViewModel.swift
@@ -370,9 +370,8 @@ class OverseerrUsersViewModel: ObservableObject {
             } catch is CancellationError {
                 plexSSOTask = nil
             } catch {
-                if case .authenticated = OverseerrAuthManager.shared.value {
-                    return
-                }
+                let current = await OverseerrAuthManager.shared.currentValue()
+                if case .authenticated = current { return }
                 print("🔴 Plex SSO failed: \(error.localizedDescription)")
                 self.connectionError = "Plex login failed. Please try again. (\(error.localizedDescription))"
                 self.authState = .unauthenticated


### PR DESCRIPTION
## Summary
- make `subject` and `value` properties of `OverseerrAuthManager` actor-isolated
- add `currentValue()` accessor
- gate Plex SSO failure handling on `currentValue()`
- adjust tests for new async API

## Testing
- `swift test --enable-test-discovery -Xswiftc -warnings-as-errors`
- `swift build`

------
https://chatgpt.com/codex/tasks/task_b_683cb83756308326a2867c86925c075c