### PR TITLE
Detach API services from main actor

### DIFF
--- a/Cantinarr/Features/OverseerrUsers/Networking/OverseerrAPIService.swift
+++ b/Cantinarr/Features/OverseerrUsers/Networking/OverseerrAPIService.swift
@@ -10,7 +10,6 @@ private let sharedDataStore = WKWebsiteDataStore.default()
 
 // OverseerrError lives in Models/OverseerrError.swift
 // keeping networking code focused on API requests.
-@MainActor
 class OverseerrAPIService {
     // MARK: – Configuration
 

--- a/Cantinarr/Features/OverseerrUsers/Networking/OverseerrServiceType.swift
+++ b/Cantinarr/Features/OverseerrUsers/Networking/OverseerrServiceType.swift
@@ -1,6 +1,5 @@
 import Foundation
 
-@MainActor
 protocol OverseerrServiceType {
     func isAuthenticated() async -> Bool
     func fetchTrending(providerIds: [Int], page: Int) async throws -> DiscoverResponse<TrendingItem>

--- a/Cantinarr/Features/OverseerrUsers/Networking/OverseerrUsersService.swift
+++ b/Cantinarr/Features/OverseerrUsers/Networking/OverseerrUsersService.swift
@@ -4,7 +4,6 @@
 import Foundation
 
 /// Abstraction for services that expose Overseerr's user‑facing API.
-@MainActor
 protocol OverseerrUsersService {
     // Check login state
     func isAuthenticated() async -> Bool

--- a/Cantinarr/Features/Radarr/RadarrAPIService.swift
+++ b/Cantinarr/Features/Radarr/RadarrAPIService.swift
@@ -4,7 +4,6 @@
 import Foundation
 
 /// Networking layer for communicating with a Radarr instance.
-@MainActor
 class RadarrAPIService {
     private let settings: RadarrSettings
     private let baseURL: URL

--- a/Cantinarr/Features/Radarr/RadarrServiceType.swift
+++ b/Cantinarr/Features/Radarr/RadarrServiceType.swift
@@ -1,6 +1,5 @@
 import Foundation
 
-@MainActor
 protocol RadarrServiceType {
     func getMovies() async throws -> [RadarrMovie]
     func getMovie(id: Int) async throws -> RadarrMovie


### PR DESCRIPTION
## Summary
- remove `@MainActor` from `OverseerrAPIService` and `RadarrAPIService`
- unmark the `OverseerrServiceType`, `OverseerrUsersService`, and `RadarrServiceType` protocols

## Testing
- `swift build`
- `swift test`

------
https://chatgpt.com/codex/tasks/task_b_683cbe51618c8326b5c1e16d5def915d