### PR TITLE
Add accessibility labels to icon buttons

### DIFF
--- a/Cantinarr/Features/OverseerrUsers/MediaDetail/UI/MediaDetailView.swift
+++ b/Cantinarr/Features/OverseerrUsers/MediaDetail/UI/MediaDetailView.swift
@@ -127,7 +127,10 @@ struct MediaDetailView: View {
     private var closeButton: some View {
         Button { dismiss() } label: {
             Image(systemName: "xmark.circle.fill")
-                .font(.title2).padding().foregroundColor(.secondary)
+                .font(.title2)
+                .padding()
+                .foregroundColor(.secondary)
+                .accessibilityLabel("Close")
         }
     }
 

--- a/Cantinarr/Features/OverseerrUsers/UI/OverseerrUsersAdvancedView.swift
+++ b/Cantinarr/Features/OverseerrUsers/UI/OverseerrUsersAdvancedView.swift
@@ -189,6 +189,7 @@ private struct ActiveKeywordsRow: View {
                         Text(kw.name).font(.caption)
                         Image(systemName: "xmark.circle.fill")
                             .foregroundColor(.secondary)
+                            .accessibilityLabel("Remove keyword")
                             .onTapGesture { remove(kw.id) }
                     }
                     .padding(.horizontal, 10)

--- a/Cantinarr/Features/OverseerrUsers/UI/OverseerrUsersExtras.swift
+++ b/Cantinarr/Features/OverseerrUsers/UI/OverseerrUsersExtras.swift
@@ -49,6 +49,7 @@ struct ActiveKeywordsView: View {
                             .font(.caption)
                         Image(systemName: "xmark.circle.fill")
                             .foregroundColor(.secondary)
+                            .accessibilityLabel("Remove keyword")
                             .onTapGesture { vm.remove(keywordID: kw.id) }
                     }
                     .padding(.horizontal, 10)

--- a/Cantinarr/Features/OverseerrUsers/UI/OverseerrUsersHomeView.swift
+++ b/Cantinarr/Features/OverseerrUsers/UI/OverseerrUsersHomeView.swift
@@ -161,6 +161,7 @@ struct OverseerrUsersHomeView: View {
             } label: {
                 Image(systemName: "xmark.circle.fill")
                     .foregroundColor(.secondary)
+                    .accessibilityLabel("Dismiss error")
             }
             .buttonStyle(.plain)
         }

--- a/Cantinarr/Features/OverseerrUsers/UI/SearchBarView.swift
+++ b/Cantinarr/Features/OverseerrUsers/UI/SearchBarView.swift
@@ -29,6 +29,7 @@ struct SearchBarView: View {
                     Image(systemName: "xmark.circle.fill")
                         .symbolRenderingMode(.hierarchical)
                         .foregroundStyle(.secondary)
+                        .accessibilityLabel("Clear search text")
                 }
                 .buttonStyle(.plain)
             }

--- a/Cantinarr/Features/Radarr/UI/RadarrMovieDetailView.swift
+++ b/Cantinarr/Features/Radarr/UI/RadarrMovieDetailView.swift
@@ -152,6 +152,7 @@ struct RadarrMovieDetailView: View {
                 .foregroundColor(.white.opacity(0.7))
                 .background(Circle().fill(Color.black.opacity(0.3))) // Slight background for better visibility
                 .shadow(radius: 3)
+                .accessibilityLabel("Close")
         }
         .padding()
     }


### PR DESCRIPTION
## Summary
- provide accessibility labels for close and clear buttons in media detail views
- label dismissible error banners in Overseerr home
- describe keyword removal buttons in advanced and extras views

## Testing
- `swift test -q`

------
https://chatgpt.com/codex/tasks/task_b_683cc3f101848326bd9f974f195af3ca