### PR TITLE
Adopt dynamic icon sizes

### DIFF
--- a/Cantinarr/Features/OverseerrUsers/OverseerrUsersHomeEntry.swift
+++ b/Cantinarr/Features/OverseerrUsers/OverseerrUsersHomeEntry.swift
@@ -105,7 +105,8 @@ struct OverseerrUsersHomeEntry: View {
             VStack(spacing: 15) {
                 Spacer()
                 Image(systemName: "link.icloud.fill") // Example icon
-                    .font(.system(size: 60))
+                    .font(.largeTitle)
+                    .imageScale(.large)
                     .foregroundColor(.blue)
                     .padding(.bottom)
                 Text("Login Required")

--- a/Cantinarr/Features/OverseerrUsers/UI/OverseerrUsersHomeView.swift
+++ b/Cantinarr/Features/OverseerrUsers/UI/OverseerrUsersHomeView.swift
@@ -124,7 +124,8 @@ struct OverseerrUsersHomeView: View {
         VStack(spacing: 15) {
             Spacer()
             Image(systemName: "wifi.exclamationmark")
-                .font(.system(size: 50))
+                .font(.largeTitle)
+                .imageScale(.large)
                 .foregroundColor(.orange)
             Text("Service Configuration Error")
                 .font(.title3)

--- a/Cantinarr/Features/Shared/UI/ServiceConnectionErrorView.swift
+++ b/Cantinarr/Features/Shared/UI/ServiceConnectionErrorView.swift
@@ -13,7 +13,8 @@ struct ServiceConnectionErrorView: View {
     var body: some View {
         VStack(spacing: 20) {
             Image(systemName: "wifi.exclamationmark")
-                .font(.system(size: 60))
+                .font(.largeTitle)
+                .imageScale(.large)
                 .foregroundColor(.orange)
 
             Text("Cannot Connect to \(serviceName)")


### PR DESCRIPTION
## Summary
- make login and error icons scale with text styles

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_b_683cd01f43248326b660eabf257d3b88