### PR TITLE
Clean up console logs with debug helper

### DIFF
--- a/Cantinarr/Core/Helpers/DebugLog.swift
+++ b/Cantinarr/Core/Helpers/DebugLog.swift
@@ -1,0 +1,8 @@
+#if DEBUG
+func debugLog(_ items: Any..., separator: String = " ", terminator: String = "\n") {
+    let message = items.map { String(describing: $0) }.joined(separator: separator)
+    print(message, terminator: terminator)
+}
+#else
+func debugLog(_ items: Any..., separator: String = " ", terminator: String = "\n") {}
+#endif

--- a/Cantinarr/Features/OverseerrUsers/Logic/OverseerrUsersViewModel.swift
+++ b/Cantinarr/Features/OverseerrUsers/Logic/OverseerrUsersViewModel.swift
@@ -130,7 +130,7 @@ class OverseerrUsersViewModel: ObservableObject {
                     try await service.loginWithPlexToken(savedToken)
                     await OverseerrAuthManager.shared.probeSession()
                 } catch {
-                    print("Failed to restore Plex token: \(error.localizedDescription)")
+                    debugLog("Failed to restore Plex token: \(error.localizedDescription)")
                     plexSSOHandler.deleteTokenFromKeychain()
                 }
             }
@@ -228,7 +228,7 @@ class OverseerrUsersViewModel: ObservableObject {
         } catch is OverseerrError {
             recoverFromAuthFailure()
         } catch {
-            print("🔴 Provider load error: \(error.localizedDescription)")
+            debugLog("🔴 Provider load error: \(error.localizedDescription)")
             connectionError = "Failed to load service configuration. \(error.localizedDescription)"
             watchProviders = []
         }
@@ -296,7 +296,7 @@ class OverseerrUsersViewModel: ObservableObject {
                 ) }
                 responsePage = rawResp.page; responseTotalPages = rawResp.totalPages
             case .person, .collection, .unknown:
-                print("⚠️ Unsupported media type for discover: \(filters.selectedMedia)")
+                debugLog("⚠️ Unsupported media type for discover: \(filters.selectedMedia)")
                 loader.cancelLoading(); return
             }
 
@@ -309,7 +309,7 @@ class OverseerrUsersViewModel: ObservableObject {
         } catch is OverseerrError {
             loader.cancelLoading(); recoverFromAuthFailure()
         } catch {
-            print("🔴 Media load error (\(filters.selectedMedia)): \(error.localizedDescription)")
+            debugLog("🔴 Media load error (\(filters.selectedMedia)): \(error.localizedDescription)")
             loader.cancelLoading()
             if loader.page == 1 || results.isEmpty {
                 connectionError = "Failed to load \(filters.selectedMedia.displayName). \(error.localizedDescription)"
@@ -372,7 +372,7 @@ class OverseerrUsersViewModel: ObservableObject {
             } catch {
                 let current = await OverseerrAuthManager.shared.currentValue()
                 if case .authenticated = current { return }
-                print("🔴 Plex SSO failed: \(error.localizedDescription)")
+                debugLog("🔴 Plex SSO failed: \(error.localizedDescription)")
                 self.connectionError = "Plex login failed. Please try again. (\(error.localizedDescription))"
                 self.authState = .unauthenticated
                 plexSSOTask = nil
@@ -383,6 +383,6 @@ class OverseerrUsersViewModel: ObservableObject {
 
 extension OverseerrUsersViewModel: OverseerrPlexSSODelegate {
     func didReceivePlexToken(_ token: String) {
-        print("⚠️ Received Plex Token via delegate (Legacy/Unexpected): \(token)")
+        debugLog("⚠️ Received Plex Token via delegate (Legacy/Unexpected): \(token)")
     }
 }

--- a/Cantinarr/Features/OverseerrUsers/Logic/PlexSSOHandler.swift
+++ b/Cantinarr/Features/OverseerrUsers/Logic/PlexSSOHandler.swift
@@ -31,7 +31,7 @@ final class PlexSSOHandler {
         let plexURL = buildPlexOAuthURL(code: pin.code)
         let web = ASWebAuthenticationSession(url: plexURL, callbackURLScheme: nil) { _, error in
             if let err = error as? ASWebAuthenticationSessionError, err.code != .canceledLogin {
-                print("ASWebAuthenticationSession failed: \(err.localizedDescription)")
+                debugLog("ASWebAuthenticationSession failed: \(err.localizedDescription)")
             }
         }
         web.presentationContextProvider = authContext

--- a/Cantinarr/Features/OverseerrUsers/Logic/SearchController.swift
+++ b/Cantinarr/Features/OverseerrUsers/Logic/SearchController.swift
@@ -127,7 +127,7 @@ final class SearchController: ObservableObject {
         } catch is OverseerrError {
             loader.cancelLoading(); recoverAuth()
         } catch {
-            print("🔴 Search error: \(error.localizedDescription)")
+            debugLog("🔴 Search error: \(error.localizedDescription)")
             loader.cancelLoading()
             if loader.page == 1 || results.isEmpty {
                 let msg = "Search failed. Check your connection and try again. (\(error.localizedDescription))"
@@ -148,7 +148,7 @@ final class SearchController: ObservableObject {
         } catch {
             keywordSuggestions = []
             keywordFetchError = "Couldn't load keyword suggestions. Check your connection and try again. (\(error.localizedDescription))"
-            print("🔴 Keyword search error: \(error.localizedDescription)")
+            debugLog("🔴 Keyword search error: \(error.localizedDescription)")
         }
         isLoadingKeywords = false
         if connectionError == nil, let err = keywordFetchError {
@@ -201,7 +201,7 @@ final class SearchController: ObservableObject {
                     } catch is OverseerrError {
                         self.recoverAuth()
                     } catch {
-                        print("⚠️ Error probing keyword \(kw.name): \(error.localizedDescription)")
+                        debugLog("⚠️ Error probing keyword \(kw.name): \(error.localizedDescription)")
                     }
                     return nil
                 }
@@ -238,12 +238,12 @@ final class SearchController: ObservableObject {
             if case .notAuthenticated = err {
                 recoverAuth()
             } else {
-                print("🔴 Movie recommendations error: \(err.localizedDescription)")
+                debugLog("🔴 Movie recommendations error: \(err.localizedDescription)")
                 movieRecs = []; movieRecLoader.reset()
             }
         } catch {
             movieFetchError = error
-            print("🔴 Movie recommendations error: \(error.localizedDescription)")
+            debugLog("🔴 Movie recommendations error: \(error.localizedDescription)")
             movieRecs = []; movieRecLoader.reset()
         }
         isLoadingMovieRecs = false
@@ -258,12 +258,12 @@ final class SearchController: ObservableObject {
             if case .notAuthenticated = err {
                 recoverAuth()
             } else {
-                print("🔴 TV recommendations error: \(err.localizedDescription)")
+                debugLog("🔴 TV recommendations error: \(err.localizedDescription)")
                 tvRecs = []; tvRecLoader.reset()
             }
         } catch {
             tvFetchError = error
-            print("🔴 TV recommendations error: \(error.localizedDescription)")
+            debugLog("🔴 TV recommendations error: \(error.localizedDescription)")
             tvRecs = []; tvRecLoader.reset()
         }
         isLoadingTvRecs = false
@@ -324,7 +324,7 @@ final class SearchController: ObservableObject {
                 movieRecLoader.cancelLoading(); recoverAuth()
             } catch {
                 movieRecLoader.cancelLoading()
-                print("🔴 Error loading more movie recommendations: \(error.localizedDescription)")
+                debugLog("🔴 Error loading more movie recommendations: \(error.localizedDescription)")
             }
         }
     }
@@ -354,7 +354,7 @@ final class SearchController: ObservableObject {
                 tvRecLoader.cancelLoading(); recoverAuth()
             } catch {
                 tvRecLoader.cancelLoading()
-                print("🔴 Error loading more TV recommendations: \(error.localizedDescription)")
+                debugLog("🔴 Error loading more TV recommendations: \(error.localizedDescription)")
             }
         }
     }

--- a/Cantinarr/Features/OverseerrUsers/Logic/TrendingViewModel.swift
+++ b/Cantinarr/Features/OverseerrUsers/Logic/TrendingViewModel.swift
@@ -78,7 +78,7 @@ final class TrendingViewModel: ObservableObject {
             // Auth errors are primarily handled by OverseerrUsersViewModel's authState
             // and OverseerrAuthManager. This VM doesn't need to set connectionError for this.
             loader.cancelLoading()
-            print("Trending fetch failed due to OverseerrError.")
+            debugLog("Trending fetch failed due to OverseerrError.")
         } catch {
             loader.cancelLoading()
             // Only set error if items are empty, otherwise it might be a pagination error
@@ -86,7 +86,7 @@ final class TrendingViewModel: ObservableObject {
             if items.isEmpty {
                 connectionError = "Failed to load trending items. Check your connection and try again."
             }
-            print("Trending fetch failed: \(error)")
+            debugLog("Trending fetch failed: \(error)")
         }
     }
 }

--- a/Cantinarr/Features/OverseerrUsers/UI/OverseerrUsersAdvancedView.swift
+++ b/Cantinarr/Features/OverseerrUsers/UI/OverseerrUsersAdvancedView.swift
@@ -430,7 +430,7 @@ class OverseerrAuthHelper: NSObject, ASWebAuthenticationPresentationContextProvi
                 let comps = URLComponents(url: callbackURL, resolvingAgainstBaseURL: false),
                 let token = comps.queryItems?.first(where: { $0.name == "token" })?.value
             else {
-                print("⚠️ Plex SSO failed: \(error?.localizedDescription ?? "no token")")
+                debugLog("⚠️ Plex SSO failed: \(error?.localizedDescription ?? \"no token\")")
                 return
             }
             DispatchQueue.main.async {

--- a/Cantinarr/Features/Radarr/Logic/RadarrMovieDetailViewModel.swift
+++ b/Cantinarr/Features/Radarr/Logic/RadarrMovieDetailViewModel.swift
@@ -51,7 +51,7 @@ class RadarrMovieDetailViewModel: ObservableObject {
             let profiles = try await radarrService.getQualityProfiles()
             qualityProfileName = profiles.first(where: { $0.id == id })?.name ?? "Unknown Profile (\(id))"
         } catch {
-            print("🔴 Failed to fetch quality profile name: \(error.localizedDescription)")
+            debugLog("🔴 Failed to fetch quality profile name: \(error.localizedDescription)")
             qualityProfileName = "Error (\(id)). Please check your Radarr settings or try again later."
         }
     }

--- a/Cantinarr/Features/Radarr/Logic/RadarrMoviesViewModel.swift
+++ b/Cantinarr/Features/Radarr/Logic/RadarrMoviesViewModel.swift
@@ -36,7 +36,7 @@ class RadarrMoviesViewModel: ObservableObject {
             self.connectionError = "Radarr API Error (\(statusCode)): \(message). Check your network connection or Radarr configuration."
         } catch {
             connectionError = "Failed to load movies: \(error.localizedDescription). Check your network connection or Radarr configuration."
-            print("🔴 Radarr Movies VM Error: \(error)")
+            debugLog("🔴 Radarr Movies VM Error: \(error)")
         }
         isLoading = false
     }
@@ -50,7 +50,7 @@ class RadarrMoviesViewModel: ObservableObject {
             }
             qualityProfiles = profileMap
         } catch {
-            print("🔴 Failed to load Radarr quality profiles: \(error.localizedDescription)")
+            debugLog("🔴 Failed to load Radarr quality profiles: \(error.localizedDescription)")
             // Non-critical, list view can show IDs or "N/A" for profile names
         }
     }

--- a/Cantinarr/Features/Radarr/Models/RadarrMovieFile.swift
+++ b/Cantinarr/Features/Radarr/Models/RadarrMovieFile.swift
@@ -13,5 +13,5 @@ struct RadarrMovieFile: Codable, Identifiable, Hashable, Equatable {
     let movieId: Int?
     let quality: RadarrHistoryQuality?
 
-    // TODO: additional fields like sceneName and indexerFlags could be added
+    // Additional fields like sceneName and indexerFlags can be added if needed
 }

--- a/Cantinarr/Features/Radarr/Models/RadarrMovieHistoryRecord.swift
+++ b/Cantinarr/Features/Radarr/Models/RadarrMovieHistoryRecord.swift
@@ -14,5 +14,5 @@ struct RadarrMovieHistoryRecord: Codable, Identifiable {
     let data: RadarrHistoryData?
     let downloadId: String?
 
-    // TODO: include movieFileId or other fields if required by Radarr updates
+    // Include movieFileId or other fields if required by future Radarr updates
 }

--- a/Cantinarr/Features/Radarr/Models/RadarrQualityProfile.swift
+++ b/Cantinarr/Features/Radarr/Models/RadarrQualityProfile.swift
@@ -8,5 +8,5 @@ struct RadarrQualityProfile: Codable, Identifiable {
     let name: String
     let cutoff: Int?
 
-    // TODO: include items array if later needed for editing profiles
+    // Items array omitted; add it if editing profiles requires it later
 }

--- a/Cantinarr/Features/Radarr/Models/RadarrSystemStatus.swift
+++ b/Cantinarr/Features/Radarr/Models/RadarrSystemStatus.swift
@@ -11,5 +11,5 @@ struct RadarrSystemStatus: Codable {
     let osVersion: String?
     let isDebug: Bool?
 
-    // TODO: include additional fields like branch, runtimeVersion if needed
+    // Additional fields like branch or runtimeVersion can be added if needed
 }

--- a/Cantinarr/Features/Radarr/RadarrAPIService.swift
+++ b/Cantinarr/Features/Radarr/RadarrAPIService.swift
@@ -168,11 +168,11 @@ class RadarrAPIService {
             return try jsonDecoder.decode(T.self, from: data)
         } catch {
             // Log the raw payload to aid debugging
-            print("🔴 Radarr decoding error for endpoint \(endpoint): \(error)")
+            debugLog("🔴 Radarr decoding error for endpoint \(endpoint): \(error)")
             if let rawDataString = String(data: data, encoding: .utf8) {
-                print("🔴 Raw data: \(rawDataString)")
+                debugLog("🔴 Raw data: \(rawDataString)")
             } else {
-                print("🔴 Raw data: Could not decode as UTF-8")
+                debugLog("🔴 Raw data: Could not decode as UTF-8")
             }
             throw error
         }

--- a/Cantinarr/Features/Shared/UI/ServiceConnectionErrorView.swift
+++ b/Cantinarr/Features/Shared/UI/ServiceConnectionErrorView.swift
@@ -54,8 +54,8 @@ struct ServiceConnectionErrorView: View {
             ServiceConnectionErrorView(
                 serviceName: "Demo Overseerr",
                 errorMessage: "The server at 192.168.1.100:5055 could not be reached. Please check your network connection or edit the service settings.",
-                onRetry: { print("Retry tapped") },
-                onEditSettings: { print("Edit Settings tapped") }
+                onRetry: { debugLog("Retry tapped") },
+                onEditSettings: { debugLog("Edit Settings tapped") }
             )
         }
     }


### PR DESCRIPTION
## Summary
- gate debug prints behind new `debugLog` helper
- remove `TODO` tags from Radarr models

## Testing
- `swift test --disable-sandbox`

------
https://chatgpt.com/codex/tasks/task_b_683d0af123c88326bb756811dc27de9b