### PR TITLE
Fix OverseerrAuthHelper logging

### DIFF
--- a/Cantinarr/Features/OverseerrUsers/UI/OverseerrUsersAdvancedView.swift
+++ b/Cantinarr/Features/OverseerrUsers/UI/OverseerrUsersAdvancedView.swift
@@ -430,7 +430,8 @@ class OverseerrAuthHelper: NSObject, ASWebAuthenticationPresentationContextProvi
                 let comps = URLComponents(url: callbackURL, resolvingAgainstBaseURL: false),
                 let token = comps.queryItems?.first(where: { $0.name == "token" })?.value
             else {
-                debugLog("⚠️ Plex SSO failed: \(error?.localizedDescription ?? \"no token\")")
+                let errorMessage = error?.localizedDescription ?? "no token"
+                debugLog("⚠️ Plex SSO failed: \(errorMessage)")
                 return
             }
             DispatchQueue.main.async {


### PR DESCRIPTION
## Summary
- adjust error logging in `OverseerrAuthHelper` to store the message in a variable

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_b_683d15f798848326ac5727c6edb9a6e9